### PR TITLE
Add build and protocol info to --version

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Prism CLI — Soroban Transaction Debugger"
+build = "build.rs"
 
 [[bin]]
 name = "prism"

--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -1,0 +1,26 @@
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-env-changed=PRISM_BUILD_HASH");
+
+    let build_hash = std::env::var("PRISM_BUILD_HASH")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(git_hash);
+
+    println!("cargo:rustc-env=PRISM_BUILD_HASH={build_hash}");
+}
+
+fn git_hash() -> String {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short=7", "HEAD"])
+        .output();
+
+    match output {
+        Ok(output) if output.status.success() => String::from_utf8(output.stdout)
+            .map(|hash| hash.trim().to_owned())
+            .unwrap_or_else(|_| "unknown".to_owned()),
+        _ => "unknown".to_owned(),
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -15,13 +15,20 @@ mod commands;
 mod output;
 mod tui;
 
-use clap::{ArgAction, Parser, Subcommand};
+use clap::{ArgAction, CommandFactory, FromArgMatches, Parser, Subcommand};
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::EnvFilter;
 
+const BUILD_HASH: &str = env!("PRISM_BUILD_HASH");
+
 /// Prism — From cryptic error to root cause in one command.
 #[derive(Parser)]
-#[command(name = "prism", version, about, long_about = None)]
+#[command(
+    name = "prism",
+    disable_version_flag = true,
+    about,
+    long_about = None
+)]
 #[command(propagate_version = true)]
 struct Cli {
     /// Subcommand to execute.
@@ -65,7 +72,9 @@ enum Commands {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let cli = Cli::parse();
+    let version = Box::leak(build_version().into_boxed_str());
+    let matches = Cli::command().version(version).get_matches();
+    let cli = Cli::from_arg_matches(&matches)?;
 
     // Initialize logging before resolving the network or dispatching commands.
     tracing_subscriber::fmt()
@@ -106,6 +115,15 @@ async fn main() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+fn build_version() -> String {
+    format!(
+        "prism {} (build: {}) | Soroban Protocol: {}",
+        prism_core::VERSION,
+        BUILD_HASH,
+        prism_core::SOROBAN_PROTOCOL_VERSION
+    )
 }
 
 fn build_log_filter(verbose: u8) -> EnvFilter {
@@ -166,5 +184,14 @@ mod tests {
         assert!(debug.contains("prism=debug"));
         assert!(trace.contains("prism=trace"));
         assert!(trace.contains("prism_core=trace"));
+    }
+
+    #[test]
+    fn version_string_includes_build_hash_and_protocol() {
+        let version = build_version();
+
+        assert!(version.contains(prism_core::VERSION));
+        assert!(version.contains(BUILD_HASH));
+        assert!(version.contains(&prism_core::SOROBAN_PROTOCOL_VERSION.to_string()));
     }
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -17,6 +17,7 @@ wasm-compat = []
 # Stellar / Soroban
 stellar-xdr = { workspace = true }
 stellar-strkey = { workspace = true }
+soroban-env-host = { workspace = true }
 soroban-spec = { workspace = true }
 soroban-spec-tools = { workspace = true }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -14,20 +14,23 @@
 //! - `debugger`: Enable Tier 3 interactive debugger (implies `replay`)
 //! - `wasm-compat`: Build for WASM target (disables features requiring native I/O)
 
+pub mod cache;
+pub mod debugger;
+pub mod decode;
+pub mod network;
+pub mod replay;
+pub mod spec;
+pub mod taxonomy;
 pub mod types;
 pub mod xdr;
-pub mod spec;
-pub mod network;
-pub mod cache;
-pub mod taxonomy;
-pub mod decode;
-pub mod replay;
-pub mod debugger;
 
 // Re-export key types for convenience
+pub use types::config::NetworkConfig;
 pub use types::error::PrismError;
 pub use types::report::DiagnosticReport;
-pub use types::config::NetworkConfig;
 
 /// Library version
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Soroban ledger protocol version supported by the linked core crates.
+pub const SOROBAN_PROTOCOL_VERSION: u32 = soroban_env_host::meta::INTERFACE_VERSION.protocol;


### PR DESCRIPTION
This pull request enhances the Prism CLI by embedding build metadata into the version output and making related improvements to the build and test process. The changes ensure that each build of the CLI includes a unique build hash and protocol version, improving traceability and debugging. Additionally, there are some minor dependency and module organization updates in the core crate.

**Build metadata and versioning improvements:**

* Added a `build.rs` script to `crates/cli` that sets a `PRISM_BUILD_HASH` environment variable at compile time, using either an environment variable or the current git commit hash. (`crates/cli/build.rs`, `crates/cli/Cargo.toml`) [[1]](diffhunk://#diff-18497b72a2306fc2560475e2548cfe1b96b6206c395380437ba1fafefd66e126R1-R26) [[2]](diffhunk://#diff-d43310c69dbd64dbe201466da69d7a4f3bd4662bbed8dd7fbab668709553627eR7)
* Updated the CLI to display a detailed version string including the build hash and Soroban protocol version, and added a test to verify this. (`crates/cli/src/main.rs`) [[1]](diffhunk://#diff-a35a356e7c041f2f9e854c8755260d2d215c3b21e0f694930df9163a5e05041fL18-R31) [[2]](diffhunk://#diff-a35a356e7c041f2f9e854c8755260d2d215c3b21e0f694930df9163a5e05041fL68-R77) [[3]](diffhunk://#diff-a35a356e7c041f2f9e854c8755260d2d215c3b21e0f694930df9163a5e05041fR120-R128) [[4]](diffhunk://#diff-a35a356e7c041f2f9e854c8755260d2d215c3b21e0f694930df9163a5e05041fR188-R196)

**Core crate updates:**

* Added `soroban-env-host` as a dependency to expose the Soroban protocol version. (`crates/core/Cargo.toml`)
* Reorganized public module declarations and re-exports in `crates/core/src/lib.rs`, and added a constant for the supported Soroban protocol version. (`crates/core/src/lib.rs`)

Closes #21 