### PR TITLE
feat(inspect): improve tx_hash positional argument display (closes #5)

### DIFF
--- a/crates/cli/src/commands/inspect.rs
+++ b/crates/cli/src/commands/inspect.rs
@@ -6,6 +6,7 @@ use prism_core::types::config::NetworkConfig;
 #[derive(Args)]
 pub struct InspectArgs {
     /// Transaction hash to inspect.
+    #[arg(value_name = "TX_HASH")]
     pub tx_hash: String,
 
     /// Show detailed fee breakdown including bid vs charged values.


### PR DESCRIPTION
## Improve `prism inspect` tx_hash argument display

This PR makes a small UX improvement to the `inspect` command by clarifying how the positional `tx_hash` argument is presented in the CLI.

---

### What’s changed

- Added `#[arg(value_name = "TX_HASH")]` to the `tx_hash` argument
- Updates CLI help output to display `<TX_HASH>` instead of `<tx_hash>`

---

### Why

- Improves clarity and consistency with common CLI conventions
- Makes it more obvious that `tx_hash` is a required positional argument
- Helps users understand expected input format at a glance

---

### Scope

- No behavior changes
- No new features or flags
- Change is localized to `inspect.rs`

---

### Checklist

- [x] `tx_hash` remains a required positional argument  
- [x] No behavior changes introduced  
- [x] No new flags or features added  
- [x] Changes limited to `inspect.rs`  
- [x] Code compiles and builds successfully  
- [x] CLI help output reflects `<TX_HASH>` correctly  

---

Closes #5