### PR TITLE
feat(cli): add global --rpc-url flag for custom RPC endpoints

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -44,6 +44,8 @@ directories = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
+url = "2"
+
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -48,6 +48,10 @@ struct Cli {
     /// Enable verbose logging. Repeat for more detail.
     #[arg(long, short, action = ArgAction::Count, global = true)]
     verbose: u8,
+
+    /// Override RPC URL (e.g. http://localhost:8000)
+    #[arg(long, global = true, value_parser = validate_url)]
+    rpc_url: Option<String>,
 }
 
 #[derive(Subcommand)]
@@ -99,7 +103,13 @@ async fn main() -> anyhow::Result<()> {
     );
 
     // Resolve network configuration
-    let network = prism_core::network::config::resolve_network(&cli.network);
+    let mut network = prism_core::network::config::resolve_network(&cli.network);
+
+    // Override RPC URL if provided
+    if let Some(ref rpc_url) = cli.rpc_url {
+        network.rpc_url = rpc_url.clone();
+    }
+
     tracing::debug!(
         resolved_network = ?network.network,
         rpc_url = %network.rpc_url,
@@ -154,6 +164,12 @@ fn build_log_filter(verbose: u8) -> EnvFilter {
                 .parse()
                 .expect("valid directive"),
         )
+}
+
+fn validate_url(value: &str) -> Result<String, String> {
+    url::Url::parse(value)
+        .map(|_| value.to_string())
+        .map_err(|_| format!("Invalid URL: {value}"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Adds a global `--rpc-url` flag to allow users to override the default RPC endpoint.

## Motivation

Developers often run local Soroban nodes or use private RPC endpoints that are not part of the predefined network list. This change enables seamless integration with such setups.

## Changes

- Added `--rpc-url` as a global CLI flag
- Validates input as a well-formed URL
- Overrides the resolved network RPC URL when provided

## Example

```bash
prism --rpc-url http://localhost:8000 decode <tx-hash>
```

Closes https://github.com/Toolbox-Lab/Prism/issues/9