### PR TITLE
feat: add --output-file option to prism profile command

### DIFF
--- a/crates/cli/src/commands/profile.rs
+++ b/crates/cli/src/commands/profile.rs
@@ -7,6 +7,10 @@ use prism_core::types::config::NetworkConfig;
 pub struct ProfileArgs {
     /// Transaction hash to profile.
     pub tx_hash: String,
+
+    /// Output profile to a file instead of stdout.
+    #[arg(long, short)]
+    pub output_file: Option<String>,
 }
 
 pub async fn run(
@@ -22,7 +26,14 @@ pub async fn run(
 
     progress.finish_and_clear();
 
-    crate::output::print_resource_profile(&trace.resource_profile, output_format)?;
+    let output = crate::output::format_resource_profile(&trace.resource_profile, output_format)?;
+
+    if let Some(path) = args.output_file {
+        std::fs::write(&path, &output)?;
+        println!("Profile written to {path}");
+    } else {
+        println!("{output}");
+    }
 
     Ok(())
 }

--- a/crates/cli/src/output/mod.rs
+++ b/crates/cli/src/output/mod.rs
@@ -71,6 +71,28 @@ pub fn print_resource_profile(
     Ok(())
 }
 
+pub fn format_resource_profile(profile: &ResourceProfile, output_format: &str) -> anyhow::Result<String> {
+    Ok(match OutputMode::parse(output_format) {
+        OutputMode::Json => serde_json::to_string_pretty(profile)?,
+        OutputMode::Short => format_resource_profile_summary(profile),
+        OutputMode::Human => {
+            let mut output = format!("{}\n", colored::Colorize::bold("Resource Profile"));
+            output.push_str(&format!(
+                "CPU: {}/{} instructions\n",
+                profile.total_cpu, profile.cpu_limit
+            ));
+            output.push_str(&format!(
+                "Memory: {}/{} bytes\n",
+                profile.total_memory, profile.memory_limit
+            ));
+            for warning in &profile.warnings {
+                output.push_str(&format!("{} {}\n", colored::Colorize::yellow("!"), warning));
+            }
+            output
+        }
+    })
+}
+
 pub fn print_state_diff(diff: &StateDiff, output_format: &str) -> anyhow::Result<()> {
     match OutputMode::parse(output_format) {
         OutputMode::Json => println!("{}", serde_json::to_string_pretty(diff)?),


### PR DESCRIPTION
Closes #6

---

close issue #6 

## PR Title: feat: add --output-file option to prism profile command

### Description
This PR enhances the `prism profile` command by adding an optional `--output-file` (or `-o`) flag, allowing users to save resource profiling results to a file instead of printing to stdout. This improves usability for cases where users want to save or further process the profiling output.

### Changes Made
- **Enhanced `ProfileArgs` struct** in `crates/cli/src/commands/profile.rs`:
  - Added `output_file: Option<String>` field with `--output-file/-o` flag
- **Added `format_resource_profile` function** in `crates/cli/src/output/mod.rs`:
  - Returns formatted profile output as a string (similar to `format_trace`)
  - Supports all output formats (human, json, compact)
- **Updated `run` function** in `crates/cli/src/commands/profile.rs`:
  - Uses `format_resource_profile` to get output string
  - Writes to file if `--output-file` is specified, otherwise prints to stdout
  - Maintains backward compatibility

### Usage
```bash
# Print to stdout (existing behavior)
prism profile <transaction-hash>

# Save to file
prism profile <transaction-hash> --output-file profile.txt
prism profile <transaction-hash> -o profile.json