### PR TITLE
feat: set default port to 3000 for prism serve

### DIFF
--- a/crates/cli/src/commands/serve.rs
+++ b/crates/cli/src/commands/serve.rs
@@ -19,7 +19,7 @@ pub struct ServeArgs {
     pub host: String,
 
     /// Port for the local bridge.
-    #[arg(long, short, default_value_t = 4040)]
+    #[arg(long, short, default_value_t = 3000)]
     pub port: u16,
 }
 


### PR DESCRIPTION
Closes #29 

# defaults to port 3000
prism serve

# bind to a custom port
prism serve --port 8080
prism serve -p 8080
