### PR TITLE
Add unit tests for get_transaction with mocked JSON responses

### DIFF
--- a/crates/core/src/rpc/client.rs
+++ b/crates/core/src/rpc/client.rs
@@ -403,4 +403,106 @@ mod tests {
         assert_eq!(result.return_value_xdr(), Some("RETVAL="));
         assert!(result.is_success());
     }
+
+    #[test]
+    fn test_get_transaction_success_status() {
+        let json = r#"{
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "status": "SUCCESS",
+                "latestLedger": 500,
+                "latestLedgerCloseTime": 1711620000,
+                "oldestLedger": 100,
+                "oldestLedgerCloseTime": 1711610000,
+                "ledger": 450,
+                "createdAt": "2024-03-28T10:00:00Z",
+                "applicationOrder": 2,
+                "envelopeXdr": "AAAAAgAAAABqYWNrQGV4YW1wbGUuY29tAAABkA==",
+                "resultXdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+                "resultMetaXdr": "AAAAAwAAAAAAAAACAAAAAwAAAcQAAAAAAAAAAA=="
+            }
+        }"#;
+
+        let resp: JsonRpcResponse<GetTransactionResponse> = serde_json::from_str(json).unwrap();
+        let result = resp.result.unwrap();
+
+        assert_eq!(result.status, TransactionStatus::Success);
+        assert_eq!(result.latest_ledger, 500);
+        assert_eq!(result.latest_ledger_close_time, Some(1711620000));
+        assert_eq!(result.oldest_ledger, Some(100));
+        assert_eq!(result.oldest_ledger_close_time, Some(1711610000));
+        assert_eq!(result.ledger, Some(450));
+        assert_eq!(result.created_at, Some("2024-03-28T10:00:00Z".to_string()));
+        assert_eq!(result.application_order, Some(2));
+        assert_eq!(result.envelope_xdr, Some("AAAAAgAAAABqYWNrQGV4YW1wbGUuY29tAAABkA==".to_string()));
+        assert_eq!(result.result_xdr, Some("AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=".to_string()));
+        assert_eq!(result.result_meta_xdr, Some("AAAAAwAAAAAAAAACAAAAAwAAAcQAAAAAAAAAAA==".to_string()));
+    }
+
+    #[test]
+    fn test_get_transaction_not_found_status() {
+        let json = r#"{
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "status": "NOT_FOUND",
+                "latestLedger": 600,
+                "latestLedgerCloseTime": 1711625000,
+                "oldestLedger": 200,
+                "oldestLedgerCloseTime": 1711615000
+            }
+        }"#;
+
+        let resp: JsonRpcResponse<GetTransactionResponse> = serde_json::from_str(json).unwrap();
+        let result = resp.result.unwrap();
+
+        assert_eq!(result.status, TransactionStatus::NotFound);
+        assert_eq!(result.latest_ledger, 600);
+        assert_eq!(result.latest_ledger_close_time, Some(1711625000));
+        assert_eq!(result.oldest_ledger, Some(200));
+        assert_eq!(result.oldest_ledger_close_time, Some(1711615000));
+        assert_eq!(result.ledger, None);
+        assert_eq!(result.created_at, None);
+        assert_eq!(result.application_order, None);
+        assert_eq!(result.envelope_xdr, None);
+        assert_eq!(result.result_xdr, None);
+        assert_eq!(result.result_meta_xdr, None);
+    }
+
+    #[test]
+    fn test_get_transaction_failed_status() {
+        let json = r#"{
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "status": "FAILED",
+                "latestLedger": 700,
+                "latestLedgerCloseTime": 1711630000,
+                "oldestLedger": 300,
+                "oldestLedgerCloseTime": 1711620000,
+                "ledger": 650,
+                "createdAt": "2024-03-28T11:00:00Z",
+                "applicationOrder": 5,
+                "envelopeXdr": "AAAAAgAAAABmYWlsZWRAdHguY29tAAABkA==",
+                "resultXdr": "AAAAAAAAAGT////7AAAAAA==",
+                "resultMetaXdr": "AAAAAwAAAAAAAAACAAAAAwAAAoYAAAAAAAAAAA=="
+            }
+        }"#;
+
+        let resp: JsonRpcResponse<GetTransactionResponse> = serde_json::from_str(json).unwrap();
+        let result = resp.result.unwrap();
+
+        assert_eq!(result.status, TransactionStatus::Failed);
+        assert_eq!(result.latest_ledger, 700);
+        assert_eq!(result.latest_ledger_close_time, Some(1711630000));
+        assert_eq!(result.oldest_ledger, Some(300));
+        assert_eq!(result.oldest_ledger_close_time, Some(1711620000));
+        assert_eq!(result.ledger, Some(650));
+        assert_eq!(result.created_at, Some("2024-03-28T11:00:00Z".to_string()));
+        assert_eq!(result.application_order, Some(5));
+        assert_eq!(result.envelope_xdr, Some("AAAAAgAAAABmYWlsZWRAdHguY29tAAABkA==".to_string()));
+        assert_eq!(result.result_xdr, Some("AAAAAAAAAGT////7AAAAAA==".to_string()));
+        assert_eq!(result.result_meta_xdr, Some("AAAAAwAAAAAAAAACAAAAAwAAAoYAAAAAAAAAAA==".to_string()));
+    }
 }

--- a/crates/core/src/xdr/codec.rs
+++ b/crates/core/src/xdr/codec.rs
@@ -171,8 +171,8 @@ mod tests {
     #[test]
     fn test_xdr_codec_round_trip() {
         let envelope = make_test_envelope();
-        let b64 = envelope.to_xdr_base64().expect("encode");
-        let decoded = TransactionEnvelope::from_xdr_base64(&b64).expect("decode");
+        let b64 = XdrCodec::to_xdr_base64(&envelope).expect("encode");
+        let decoded = <TransactionEnvelope as XdrCodec>::from_xdr_base64(&b64).expect("decode");
         assert_eq!(envelope, decoded);
     }
 
@@ -200,7 +200,7 @@ mod tests {
         ];
         
         let b64 = encode_xdr_base64(&xdr_bytes);
-        let meta = TransactionMeta::from_xdr_base64(&b64).expect("decode V3");
+        let meta = <TransactionMeta as XdrCodec>::from_xdr_base64(&b64).expect("decode V3");
 
         if let TransactionMeta::V3(v3) = meta {
             assert_eq!(v3.operations.len(), 1);
@@ -224,8 +224,8 @@ mod tests {
         let xdr_bytes = vec![0u8; 20];
         let bytes = encode_xdr_base64(&xdr_bytes);
         
-        let decoded = TransactionResult::from_xdr_base64(&bytes).expect("decode");
-        let encoded = decoded.to_xdr_base64().expect("encode");
+        let decoded = <TransactionResult as XdrCodec>::from_xdr_base64(&bytes).expect("decode");
+        let encoded = XdrCodec::to_xdr_base64(&decoded).expect("encode");
         
         assert_eq!(bytes, encoded);
     }


### PR DESCRIPTION
Add three comprehensive unit tests for the get_transaction method in
crates/core/src/rpc/client.rs that verify correct deserialization of
GetTransactionResponse for all transaction statuses:

- test_get_transaction_success_status: Validates SUCCESS status with
  all optional fields populated (ledger, createdAt, envelopeXdr, etc.)
  
- test_get_transaction_not_found_status: Validates NOT_FOUND status
  with minimal fields and ensures optional fields are None
  
- test_get_transaction_failed_status: Validates FAILED status with
  complete transaction data including error metadata

Each test mocks a complete JSON-RPC response and asserts correct
parsing of all fields including the TransactionStatus enum variants.

Fix ambiguous method call errors in xdr/codec.rs tests by using
fully-qualified trait syntax (XdrCodec::to_xdr_base64 and 
<Type as XdrCodec>::from_xdr_base64) to disambiguate between the
custom XdrCodec trait and stellar_xdr's WriteXdr/ReadXdr traits,
which was blocking test compilation.

Test

run 

``` 
cargo test --package prism-core --lib -- test_get_transaction

```

closes #166
