### PR TITLE
feat: setup global tracing subscriber for tests

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -47,3 +47,5 @@ thiserror = { workspace = true }
 [dev-dependencies]
 tokio-test = "0.4"
 insta = { version = "1", features = ["json"] }
+tracing-subscriber = { workspace = true }
+ctor = "0.2"

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -40,3 +40,17 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// Soroban ledger protocol version supported by the linked core crates.
 pub const SOROBAN_PROTOCOL_VERSION: u32 =
     soroban_env_host::meta::get_ledger_protocol_version(soroban_env_host::meta::INTERFACE_VERSION);
+
+#[cfg(test)]
+#[ctor::ctor]
+fn init_test_logging() {
+    use tracing_subscriber::EnvFilter;
+
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("prism_core=debug,soroban_env_host=warn"));
+
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_test_writer()
+        .try_init();
+}


### PR DESCRIPTION

Debugging tests in `prism-core` was difficult due to the lack of visible logs. This PR introduces a global tracing initialization hook that automatically sets up a formatted subscriber whenever tests are run.

## Key Changes

* **`crates/core/Cargo.toml`:** Added `ctor` and `tracing-subscriber` to `dev-dependencies`.
* **`crates/core/src/lib.rs`:** Added a `#[ctor]`-indexed `init_test_logging` function that configures a `tracing-subscriber` with a default `debug` filter for the core crate.
* The subscriber is configured with `with_test_writer()`, meaning logs will only appear in `cargo test -- --nocapture` or on test failures.
closes #164 