### PR TITLE
 feat: add dedicated JSON-RPC 2.0 error representation

### DIFF
--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -1,6 +1,16 @@
 //! Error types for the Prism crate.
 
 use thiserror::Error;
+use serde::{Deserialize, Serialize};
+
+/// Standard JSON-RPC 2.0 error object.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct JsonRpcError {
+    /// Standard JSON-RPC error code.
+    pub code: i64,
+    /// Human-readable error message.
+    pub message: String,
+}
 
 /// Top-level error type for all Prism operations.
 #[derive(Debug, Error)]
@@ -12,6 +22,10 @@ pub enum PrismError {
     /// Error communicating with the Soroban RPC endpoint.
     #[error("RPC error: {0}")]
     RpcError(String),
+
+    /// Standard JSON-RPC 2.0 error (e.g. Parse error, Invalid request).
+    #[error("JSON-RPC error (code: {0.code}): {0.message}")]
+    JsonRpc(JsonRpcError),
     
     /// Error fetching or parsing history archive data.
     #[error("Archive error: {0}")]

--- a/crates/core/src/rpc/client.rs
+++ b/crates/core/src/rpc/client.rs
@@ -285,9 +285,10 @@ impl SorobanRpcClient {
                             endpoint = %self.rpc_url,
                             attempt,
                             error = %err.message,
+                            code = err.code,
                             "RPC returned an error response"
                         );
-                        return Err(PrismError::RpcError(err.message));
+                        return Err(PrismError::JsonRpc(err));
                     }
 
                     return rpc_response.result.ok_or_else(|| {

--- a/crates/core/src/rpc/jsonrpc.rs
+++ b/crates/core/src/rpc/jsonrpc.rs
@@ -3,7 +3,7 @@
 //! Provides strongly-typed request/response envelopes and a reusable HTTP
 //! transport so every RPC call is validated at compile time via Serde.
 
-use crate::error::{PrismError, PrismResult};
+use crate::error::{PrismError, PrismResult, JsonRpcError};
 use serde::{Deserialize, Serialize};
 use std::time::Instant;
 
@@ -38,13 +38,6 @@ pub struct JsonRpcResponse<T> {
     pub id: u64,
     pub result: Option<T>,
     pub error: Option<JsonRpcError>,
-}
-
-/// JSON-RPC error object returned inside a response.
-#[derive(Debug, Deserialize)]
-pub struct JsonRpcError {
-    pub code: i64,
-    pub message: String,
 }
 
 // ── Soroban RPC param/result types ───────────────────────────────────────────
@@ -162,9 +155,10 @@ impl JsonRpcTransport {
                             method,
                             endpoint = %self.endpoint,
                             error = %err.message,
+                            code = err.code,
                             "RPC returned error response"
                         );
-                        return Err(PrismError::RpcError(err.message));
+                        return Err(PrismError::JsonRpc(err));
                     }
 
                     return envelope


### PR DESCRIPTION

Previously, JSON-RPC errors were flattened into a generic `RpcError(String)`, losing the specific error code provided by the node. This PR introduces a structured way to handle these errors.

## Key Changes

* **`crates/core/src/error.rs`:**
  * Added `JsonRpcError` struct with `code` and `message` fields.
  * Added `PrismError::JsonRpc` variant using the new struct.
* **`crates/core/src/rpc/jsonrpc.rs`:**
  * Removed local `JsonRpcError` definition.
  * Updated response parsing to use the centralized error type.
* **`crates/core/src/rpc/client.rs`:**
  * Updated `getTransaction` and other calls to return `PrismError::JsonRpc` when the node reports a protocol error.

closes #173 