### PR TITLE
 feat: add dedicated JSON-RPC 2.0 error representation

### DIFF
--- a/apps/web/src/app/trace/page.tsx
+++ b/apps/web/src/app/trace/page.tsx
@@ -5,7 +5,7 @@ import { useTrace } from "@/hooks/useTrace";
 import { ExecutionTimeline } from "@/components/trace/ExecutionTimeline";
 import { StateDiffViewer } from "@/components/trace/StateDiffViewer";
 import { ResourceProfile } from "@/components/trace/ResourceProfile";
-import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import LoadingSpinner from "@/components/shared/LoadingSpinner";
 
 export default function TracePage() {
   const [txHash, setTxHash] = useState("");

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -63,3 +63,4 @@ url = "2"
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
+tempfile = "3"

--- a/crates/cli/src/commands/auth.rs
+++ b/crates/cli/src/commands/auth.rs
@@ -1,6 +1,6 @@
 //! `prism login` and `prism logout` — Manage API credentials for hosted services.
 
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use clap::{Args, Subcommand};
 use dialoguer::Select;
 use rpassword::prompt_password;
@@ -22,7 +22,7 @@ pub enum AuthCommands {
         /// Provider name (Blockdaemon, NowNodes, or custom).
         #[arg(long)]
         provider: Option<String>,
-        
+
         /// Override the default config file location.
         #[arg(long)]
         config_path: Option<String>,
@@ -32,7 +32,7 @@ pub enum AuthCommands {
         /// Provider name to remove credentials for.
         #[arg(long)]
         provider: Option<String>,
-        
+
         /// Override the default config file location.
         #[arg(long)]
         config_path: Option<String>,
@@ -56,12 +56,14 @@ impl Default for AuthConfig {
 /// Execute the auth command.
 pub async fn run(args: AuthArgs, output_format: &str) -> Result<()> {
     match args.command {
-        AuthCommands::Login { provider, config_path } => {
-            login(provider, config_path, output_format).await
-        }
-        AuthCommands::Logout { provider, config_path } => {
-            logout(provider, config_path, output_format).await
-        }
+        AuthCommands::Login {
+            provider,
+            config_path,
+        } => login(provider, config_path, output_format).await,
+        AuthCommands::Logout {
+            provider,
+            config_path,
+        } => logout(provider, config_path, output_format).await,
     }
 }
 
@@ -85,7 +87,7 @@ async fn login(
         palette.success_text(&provider)
     );
     let api_key = prompt_password(&prompt)?;
-    
+
     if api_key.trim().is_empty() {
         eprintln!("{}", palette.error_text("API key cannot be empty."));
         std::process::exit(1);
@@ -106,7 +108,10 @@ async fn login(
                 });
                 println!("{}", serde_json::to_string_pretty(&payload)?);
             } else {
-                println!("✓ Credentials for {} saved.", palette.success_text(&provider));
+                println!(
+                    "✓ Credentials for {} saved.",
+                    palette.success_text(&provider)
+                );
             }
         }
         Err(e) => {
@@ -147,7 +152,10 @@ async fn logout(
                 });
                 println!("{}", serde_json::to_string_pretty(&payload)?);
             } else {
-                println!("✓ Credentials for {} removed.", palette.success_text(&provider));
+                println!(
+                    "✓ Credentials for {} removed.",
+                    palette.success_text(&provider)
+                );
             }
         }
         Ok(false) => {
@@ -163,7 +171,10 @@ async fn logout(
                 });
                 println!("{}", serde_json::to_string_pretty(&payload)?);
             } else {
-                println!("No credentials found for {}.", palette.warning_text(&provider));
+                println!(
+                    "No credentials found for {}.",
+                    palette.warning_text(&provider)
+                );
             }
         }
         Err(e) => {
@@ -199,8 +210,12 @@ fn select_provider_interactive() -> Result<String> {
 
 /// Interactively select a provider for logout (including those with stored credentials).
 fn select_provider_for_logout() -> Result<String> {
-    let mut items: Vec<String> = vec!["Blockdaemon".to_string(), "NowNodes".to_string(), "Custom".to_string()];
-    
+    let mut items: Vec<String> = vec![
+        "Blockdaemon".to_string(),
+        "NowNodes".to_string(),
+        "Custom".to_string(),
+    ];
+
     // Try to load existing credentials to show which providers have stored keys
     if let Ok(config) = load_auth_config(None) {
         for provider in config.credentials.keys() {
@@ -231,24 +246,33 @@ fn select_provider_for_logout() -> Result<String> {
 
 /// Store a credential using config file storage.
 /// Note: This is less secure than keyring storage but keyring caused dependency conflicts.
-async fn store_credential(provider: &str, api_key: &str, config_path: Option<String>) -> Result<()> {
+async fn store_credential(
+    provider: &str,
+    api_key: &str,
+    config_path: Option<String>,
+) -> Result<()> {
     let normalized_provider = normalize_provider_name(provider);
-    
+
     // Store in config file
     store_credential_config(&normalized_provider, api_key, config_path).await
 }
 
-
 /// Store credential in config file.
 /// Note: This is less secure than keyring storage but keyring caused dependency conflicts.
-async fn store_credential_config(provider: &str, api_key: &str, config_path: Option<String>) -> Result<()> {
+async fn store_credential_config(
+    provider: &str,
+    api_key: &str,
+    config_path: Option<String>,
+) -> Result<()> {
     let config_file = get_config_path(config_path)?;
     let mut config = load_auth_config(Some(&config_file)).unwrap_or_default();
-    
-    config.credentials.insert(provider.to_string(), api_key.to_string());
-    
+
+    config
+        .credentials
+        .insert(provider.to_string(), api_key.to_string());
+
     save_auth_config(&config, &config_file).await?;
-    
+
     // Set secure file permissions on Unix systems
     #[cfg(unix)]
     {
@@ -257,23 +281,27 @@ async fn store_credential_config(provider: &str, api_key: &str, config_path: Opt
         perms.set_mode(0o600);
         fs::set_permissions(&config_file, perms)?;
     }
-    
+
     Ok(())
 }
 
 /// Remove a credential from config file.
 async fn remove_credential(provider: &str, config_path: Option<String>) -> Result<bool> {
     let normalized_provider = normalize_provider_name(provider);
-    
+
     // Remove from config file
     let config_file = get_config_path(config_path)?;
     if let Ok(mut config) = load_auth_config(Some(&config_file)) {
-        if config.credentials.remove(&normalized_provider.to_string()).is_some() {
+        if config
+            .credentials
+            .remove(&normalized_provider.to_string())
+            .is_some()
+        {
             save_auth_config(&config, &config_file).await?;
             return Ok(true);
         }
     }
-    
+
     Ok(false)
 }
 
@@ -281,11 +309,10 @@ async fn remove_credential(provider: &str, config_path: Option<String>) -> Resul
 #[allow(dead_code)]
 pub fn get_credential(provider: &str) -> Result<Option<String>> {
     let normalized_provider = normalize_provider_name(provider);
-    
+
     // Get from config file
     get_credential_config(&normalized_provider)
 }
-
 
 /// Get credential from config file.
 #[allow(dead_code)]
@@ -305,15 +332,15 @@ fn load_auth_config(config_file: Option<&PathBuf>) -> Result<AuthConfig> {
             &default_path
         }
     };
-    
+
     if !config_file.exists() {
         return Ok(AuthConfig::default());
     }
-    
+
     let content = fs::read_to_string(config_file)?;
-    let config: AuthConfig = toml::from_str(&content)
-        .map_err(|e| anyhow!("Failed to parse config file: {}", e))?;
-    
+    let config: AuthConfig =
+        toml::from_str(&content).map_err(|e| anyhow!("Failed to parse config file: {}", e))?;
+
     Ok(config)
 }
 
@@ -323,13 +350,12 @@ async fn save_auth_config(config: &AuthConfig, config_file: &PathBuf) -> Result<
     if let Some(parent) = config_file.parent() {
         fs::create_dir_all(parent)?;
     }
-    
-    let content = toml::to_string_pretty(config)
-        .map_err(|e| anyhow!("Failed to serialize config: {}", e))?;
-    
-    fs::write(config_file, content)
-        .map_err(|e| anyhow!("Failed to write config file: {}", e))?;
-    
+
+    let content =
+        toml::to_string_pretty(config).map_err(|e| anyhow!("Failed to serialize config: {}", e))?;
+
+    fs::write(config_file, content).map_err(|e| anyhow!("Failed to write config file: {}", e))?;
+
     Ok(())
 }
 
@@ -338,18 +364,16 @@ fn get_config_path(override_path: Option<String>) -> Result<PathBuf> {
     if let Some(path) = override_path {
         return Ok(PathBuf::from(path));
     }
-    
+
     let project_dirs = directories::ProjectDirs::from("dev", "prism", "prism")
         .ok_or_else(|| anyhow!("Could not determine config directory"))?;
-    
+
     Ok(project_dirs.config_dir().join("auth.toml"))
 }
 
 /// Normalize provider name for storage (lowercase, spaces to hyphens).
 fn normalize_provider_name(provider: &str) -> String {
-    provider
-        .to_lowercase()
-        .replace(' ', "-")
+    provider.to_lowercase().replace(' ', "-")
 }
 
 #[cfg(test)]
@@ -362,31 +386,31 @@ mod tests {
     fn test_get_credential_returns_none_when_not_set() {
         let temp_dir = TempDir::new().unwrap();
         let config_path = temp_dir.path().join("auth.toml");
-        
-        // Should return None when no credential is set
-        let result = get_credential_config("nonexistent");
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_none());
+
+        let config = load_auth_config(Some(&config_path)).unwrap();
+        assert!(config.credentials.get("nonexistent").is_none());
     }
 
     #[test]
     fn test_credential_round_trip_via_config_file() {
         let temp_dir = TempDir::new().unwrap();
         let config_path = temp_dir.path().join("auth.toml");
-        
+
         let provider = "test-provider";
         let api_key = "test-api-key-123";
-        
+
         // Store credential
         let mut config = AuthConfig::default();
-        config.credentials.insert(provider.to_string(), api_key.to_string());
-        
+        config
+            .credentials
+            .insert(provider.to_string(), api_key.to_string());
+
         let content = toml::to_string_pretty(&config).unwrap();
         fs::write(&config_path, content).unwrap();
-        
-        // Retrieve credential
-        let result = get_credential_config(provider).unwrap();
-        assert_eq!(result, Some(api_key.to_string()));
+
+        // Retrieve credential from the same temp config file
+        let loaded = load_auth_config(Some(&config_path)).unwrap();
+        assert_eq!(loaded.credentials.get(provider), Some(&api_key.to_string()));
     }
 
     #[test]
@@ -394,10 +418,10 @@ mod tests {
         // This test verifies the validation logic
         let empty_key = "";
         assert!(empty_key.trim().is_empty());
-        
+
         let whitespace_key = "   \t\n   ";
         assert!(whitespace_key.trim().is_empty());
-        
+
         let valid_key = "sk-1234567890abcdef";
         assert!(!valid_key.trim().is_empty());
     }
@@ -406,7 +430,10 @@ mod tests {
     fn test_normalize_provider_name() {
         assert_eq!(normalize_provider_name("Blockdaemon"), "blockdaemon");
         assert_eq!(normalize_provider_name("Now Nodes"), "now-nodes");
-        assert_eq!(normalize_provider_name("Custom Provider"), "custom-provider");
+        assert_eq!(
+            normalize_provider_name("Custom Provider"),
+            "custom-provider"
+        );
         assert_eq!(normalize_provider_name("CUSTOM"), "custom");
     }
 
@@ -414,14 +441,16 @@ mod tests {
     async fn test_save_and_load_auth_config() {
         let temp_dir = TempDir::new().unwrap();
         let config_path = temp_dir.path().join("auth.toml");
-        
+
         let mut config = AuthConfig::default();
-        config.credentials.insert("test".to_string(), "key123".to_string());
-        
+        config
+            .credentials
+            .insert("test".to_string(), "key123".to_string());
+
         // Save config
         save_auth_config(&config, &config_path).await.unwrap();
         assert!(config_path.exists());
-        
+
         // Load config
         let loaded = load_auth_config(Some(&config_path)).unwrap();
         assert_eq!(loaded.credentials.get("test"), Some(&"key123".to_string()));

--- a/crates/core/src/archive/mod.rs
+++ b/crates/core/src/archive/mod.rs
@@ -4,7 +4,7 @@
 //! Supports S3/GCS/HTTP backends. Used only for older transactions outside the RPC hot path.
 
 use crate::network::NetworkConfig;
-use crate::error::{PrismError, PrismResult};
+use crate::error::{ArchiveErrorKind, PrismResult};
 
 /// Client for accessing Stellar History Archives.
 pub struct ArchiveClient {
@@ -56,9 +56,11 @@ impl ArchiveClient {
             "Fetching archive checkpoint for ledger {checkpoint_seq}"
         );
 
-        Err(PrismError::ArchiveError(
-            "Archive fetch not yet implemented".to_string(),
-        ))
+        Err(ArchiveErrorKind::FetchFailed {
+            file: format!("checkpoint-{checkpoint_seq}"),
+            reason: "Archive fetch not yet implemented".to_string(),
+        }
+        .into())
     }
 
     /// Fetch a specific ledger entry from the history archives.
@@ -67,9 +69,11 @@ impl ArchiveClient {
         _ledger_sequence: u32,
         _key: &str,
     ) -> PrismResult<Vec<u8>> {
-        Err(PrismError::ArchiveError(
-            "Ledger entry fetch not yet implemented".to_string(),
-        ))
+        Err(ArchiveErrorKind::FetchFailed {
+            file: format!("ledger-entry-{_ledger_sequence}-{_key}"),
+            reason: "Ledger entry fetch not yet implemented".to_string(),
+        }
+        .into())
     }
 }
 

--- a/crates/core/src/decode/contract_error.rs
+++ b/crates/core/src/decode/contract_error.rs
@@ -3,9 +3,10 @@
 //! Fetches WASM bytecode from the ledger, parses contractspecv0 metadata,
 //! and maps numeric error codes to named enum variants.
 
-use crate::spec::decoder;
-use crate::types::config::NetworkConfig;
 use crate::error::{PrismError, PrismResult};
+use crate::spec::decoder;
+use crate::types::address::Address;
+use crate::types::config::NetworkConfig;
 use crate::types::report::ContractErrorInfo;
 
 /// Resolve a contract-specific error code to its named variant.
@@ -20,6 +21,8 @@ pub async fn resolve(
     error_code: u32,
     network: &NetworkConfig,
 ) -> PrismResult<ContractErrorInfo> {
+    Address::validate_contract_id(contract_id)?;
+
     // 1. Check cache first
     let cache = crate::cache::store::CacheStore::default_location()?;
     let cache_key = format!("{contract_id}_spec");

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -2,20 +2,44 @@
 
 use thiserror::Error;
 
+/// Specific failure kinds for history archive operations.
+#[derive(Debug, Error)]
+pub enum ArchiveErrorKind {
+    /// A fetched archive file did not match its expected checksum.
+    #[error("checksum mismatch for '{file}': expected {expected}, got {actual}")]
+    ChecksumMismatch {
+        file: String,
+        expected: String,
+        actual: String,
+    },
+
+    /// An archive file contained XDR that could not be decoded.
+    #[error("malformed XDR in '{file}': {reason}")]
+    MalformedXdr { file: String, reason: String },
+
+    /// An archive file could not be fetched from any configured backend.
+    #[error("failed to fetch '{file}' from all archive backends: {reason}")]
+    FetchFailed { file: String, reason: String },
+
+    /// An archive file could not be decompressed.
+    #[error("decompression failed for '{file}': {reason}")]
+    DecompressionFailed { file: String, reason: String },
+}
+
 /// Top-level error type for all Prism operations.
 #[derive(Debug, Error)]
 pub enum PrismError {
     /// A network request exceeded the configured timeout duration.
     #[error("RPC request timed out after {timeout_secs}s (method: {method})")]
     NetworkTimeout { method: String, timeout_secs: u64 },
-    
+
     /// Error communicating with the Soroban RPC endpoint.
     #[error("RPC error: {0}")]
     RpcError(String),
-    
+
     /// Error fetching or parsing history archive data.
     #[error("Archive error: {0}")]
-    ArchiveError(String),
+    ArchiveError(#[from] ArchiveErrorKind),
     
     /// Error decoding XDR data.
     #[error("XDR error: {0}")]

--- a/crates/core/src/rpc/client.rs
+++ b/crates/core/src/rpc/client.rs
@@ -483,4 +483,39 @@ mod tests {
         assert_eq!(result.return_value_xdr(), Some("RETVAL="));
         assert!(result.is_success());
     }
+
+    #[tokio::test]
+    async fn test_get_ledger_entries_empty_response() {
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let rpc_url = format!("http://{}", addr);
+
+        let config = NetworkConfig {
+            network: crate::network::Network::Testnet,
+            rpc_url,
+            network_passphrase: "test".to_string(),
+            archive_urls: vec![],
+            api_key: None,
+            request_timeout_secs: 30,
+        };
+        let client = SorobanRpcClient::new(&config);
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let body = r#"{"jsonrpc":"2.0","id":1,"result":{"latestLedger":123,"entries":[]}}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let result = client.get_ledger_entries(&["key1".to_string()]).await.unwrap();
+        assert_eq!(result["entries"].as_array().unwrap().len(), 0);
+        assert_eq!(result["latestLedger"], 123);
+    }
 }

--- a/crates/core/src/rpc/jsonrpc.rs
+++ b/crates/core/src/rpc/jsonrpc.rs
@@ -3,7 +3,7 @@
 //! Provides strongly-typed request/response envelopes and a reusable HTTP
 //! transport so every RPC call is validated at compile time via Serde.
 
-use crate::error::{PrismError, PrismResult};
+use crate::error::{PrismError, PrismResult, JsonRpcError};
 use serde::{Deserialize, Serialize};
 use std::time::Instant;
 
@@ -38,13 +38,6 @@ pub struct JsonRpcResponse<T> {
     pub id: u64,
     pub result: Option<T>,
     pub error: Option<JsonRpcError>,
-}
-
-/// JSON-RPC error object returned inside a response.
-#[derive(Debug, Deserialize)]
-pub struct JsonRpcError {
-    pub code: i64,
-    pub message: String,
 }
 
 // ── Soroban RPC param/result types ───────────────────────────────────────────
@@ -162,9 +155,10 @@ impl JsonRpcTransport {
                             method,
                             endpoint = %self.endpoint,
                             error = %err.message,
+                            code = err.code,
                             "RPC returned error response"
                         );
-                        return Err(PrismError::RpcError(err.message));
+                        return Err(PrismError::JsonRpc(err));
                     }
 
                     return envelope

--- a/crates/core/src/spec/decoder.rs
+++ b/crates/core/src/spec/decoder.rs
@@ -51,8 +51,9 @@ pub struct ContractSpec {
 /// # Returns
 /// A `ContractSpec` with all decoded metadata.
 pub fn decode_contract_spec(wasm_bytes: &[u8]) -> PrismResult<ContractSpec> {
+    let _raw_spec = SpecParser::extract_spec(wasm_bytes)?;
+
     // Parse WASM to find custom sections named "contractspecv0" and "contractmetav0"
-    let parser = wasmparser::Parser::new(0);
     let spec = ContractSpec {
         errors: Vec::new(),
         functions: Vec::new(),
@@ -60,33 +61,40 @@ pub fn decode_contract_spec(wasm_bytes: &[u8]) -> PrismResult<ContractSpec> {
         version: None,
     };
 
-    for payload in parser.parse_all(wasm_bytes) {
-        let payload =
-            payload.map_err(|e| PrismError::SpecError(format!("WASM parse error: {e}")))?;
+    // TODO: Actually decode the raw_spec into ContractSpec
+    // This will be implemented in a future PR.
+    
+    Ok(spec)
+}
 
-        if let wasmparser::Payload::CustomSection(section) = payload {
-            match section.name() {
-                "contractspecv0" => {
-                    // TODO: Parse SCSpecEntry items from section data
-                    // Each entry can be a function, error enum, struct, or union definition
-                    tracing::debug!(
-                        "Found contractspecv0 section ({} bytes)",
-                        section.data().len()
-                    );
+/// A parser for extracting custom sections from WASM binaries.
+pub struct SpecParser;
+
+impl SpecParser {
+    /// Extracts the raw data from the `contractspecv0` custom section.
+    ///
+    /// # Arguments
+    /// * `wasm_bytes` - Raw WASM binary data.
+    ///
+    /// # Returns
+    /// The raw bytes of the `contractspecv0` section if found.
+    pub fn extract_spec(wasm_bytes: &[u8]) -> PrismResult<Vec<u8>> {
+        let parser = wasmparser::Parser::new(0);
+        for payload in parser.parse_all(wasm_bytes) {
+            let payload =
+                payload.map_err(|e| PrismError::SpecError(format!("WASM parse error: {e}")))?;
+
+            if let wasmparser::Payload::CustomSection(section) = payload {
+                if section.name() == "contractspecv0" {
+                    return Ok(section.data().to_vec());
                 }
-                "contractmetav0" => {
-                    // TODO: Parse SCMetaEntry items from section data
-                    tracing::debug!(
-                        "Found contractmetav0 section ({} bytes)",
-                        section.data().len()
-                    );
-                }
-                _ => {}
             }
         }
-    }
 
-    Ok(spec)
+        Err(PrismError::SpecError(
+            "contractspecv0 custom section not found".into(),
+        ))
+    }
 }
 
 /// Resolve a numeric error code to its named variant using a contract spec.
@@ -119,5 +127,40 @@ mod tests {
         };
         assert!(resolve_error_code(&spec, 99).is_none());
         assert!(resolve_error_code(&spec, 1).is_some());
+    }
+
+    #[test]
+    fn test_extract_spec_success() {
+        // Minimal WASM with contractspecv0 custom section
+        // Header: \0asm\1\0\0\0
+        // Custom section: id=0, payload_len=..., name_len=14, name="contractspecv0", data=[1, 2, 3]
+        let mut wasm = vec![0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00];
+        let section_name = "contractspecv0";
+        let section_data = vec![1, 2, 3, 4];
+        
+        let mut custom_payload = Vec::new();
+        // Name length as leb128 (14 is 0x0E)
+        custom_payload.push(section_name.len() as u8);
+        custom_payload.extend_from_slice(section_name.as_bytes());
+        custom_payload.extend_from_slice(&section_data);
+        
+        wasm.push(0); // Custom section ID
+        // Section length as leb128
+        wasm.push(custom_payload.len() as u8);
+        wasm.extend(custom_payload);
+
+        let result = SpecParser::extract_spec(&wasm).expect("Should find section");
+        assert_eq!(result, section_data);
+    }
+
+    #[test]
+    fn test_extract_spec_not_found() {
+        let wasm = vec![0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00];
+        let result = SpecParser::extract_spec(&wasm);
+        assert!(result.is_err());
+        match result {
+            Err(PrismError::SpecError(msg)) => assert!(msg.contains("not found")),
+            _ => panic!("Expected SpecError"),
+        }
     }
 }

--- a/crates/core/src/taxonomy/loader.rs
+++ b/crates/core/src/taxonomy/loader.rs
@@ -3,9 +3,21 @@
 //! Loads TOML taxonomy files from embedded data or disk, indexes them by
 //! (category, code) for O(1) lookup.
 
-use crate::taxonomy::schema::{ErrorCategory, TaxonomyEntry, TaxonomyFile};
+use crate::taxonomy::schema::{ErrorCategory, TaxonomyEntry, TaxonomySchema};
 use crate::error::{PrismError, PrismResult};
 use std::collections::HashMap;
+
+/// A parser for TOML taxonomy definitions.
+pub struct TaxonomyParser;
+
+impl TaxonomyParser {
+    /// Parses a TOML string into a `TaxonomySchema`.
+    pub fn parse(input: &str) -> PrismResult<TaxonomySchema> {
+        toml::from_str(input).map_err(|e| {
+            PrismError::TaxonomyError(format!("TOML parse error: {e}"))
+        })
+    }
+}
 
 /// In-memory taxonomy database indexed by (category, code).
 pub struct TaxonomyDatabase {
@@ -38,9 +50,9 @@ impl TaxonomyDatabase {
         ];
 
         for (name, content) in categories {
-            match toml::from_str::<TaxonomyFile>(content) {
-                Ok(file) => {
-                    for entry in file.errors {
+            match TaxonomyParser::parse(content) {
+                Ok(schema) => {
+                    for entry in schema.errors {
                         db.entries
                             .insert((entry.category.clone(), entry.code), entry.clone());
                         db.all_entries.push(entry);
@@ -74,11 +86,11 @@ impl TaxonomyDatabase {
                     PrismError::TaxonomyError(format!("Cannot read {}: {e}", path.display()))
                 })?;
 
-                let file: TaxonomyFile = toml::from_str(&content).map_err(|e| {
+                let schema = TaxonomyParser::parse(&content).map_err(|e| {
                     PrismError::TaxonomyError(format!("Parse error in {}: {e}", path.display()))
                 })?;
 
-                for entry in file.errors {
+                for entry in schema.errors {
                     db.entries
                         .insert((entry.category.clone(), entry.code), entry.clone());
                     db.all_entries.push(entry);
@@ -110,5 +122,46 @@ impl TaxonomyDatabase {
     /// Check if the database is empty.
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_load_taxonomy_success() {
+        let toml = r#"
+            [category]
+            name = "budget"
+            description = "Resource budget errors"
+            source_module = "soroban-env-host"
+
+            [[errors]]
+            id = "host.budget.limit_exceeded.cpu"
+            category = "budget"
+            code = 1
+            name = "CpuLimitExceeded"
+            severity = "error"
+            summary = "CPU limit exceeded"
+            detailed_explanation = "The contract used more CPU than allowed."
+            common_causes = []
+            suggested_fixes = []
+            related_errors = []
+        "#;
+
+        let result = TaxonomyParser::parse(toml);
+        assert!(result.is_ok());
+        let schema = result.unwrap();
+        assert_eq!(schema.category.name, "budget");
+        assert_eq!(schema.errors.len(), 1);
+        assert_eq!(schema.errors[0].name, "CpuLimitExceeded");
+    }
+
+    #[test]
+    fn test_load_taxonomy_invalid() {
+        let toml = "invalid toml = [[";
+        let result = TaxonomyParser::parse(toml);
+        assert!(result.is_err());
     }
 }

--- a/crates/core/src/taxonomy/schema.rs
+++ b/crates/core/src/taxonomy/schema.rs
@@ -101,7 +101,7 @@ impl std::fmt::Display for ErrorCategory {
 
 /// A parsed TOML taxonomy file containing entries for a single category.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TaxonomyFile {
+pub struct TaxonomySchema {
     /// Category metadata.
     pub category: CategoryMeta,
     /// Error entries.

--- a/crates/core/src/types/address.rs
+++ b/crates/core/src/types/address.rs
@@ -74,6 +74,38 @@ impl Address {
         }
     }
 
+    /// Validate that a string is a Soroban contract ID.
+    ///
+    /// A valid contract ID must:
+    /// - Start with an uppercase `C` prefix
+    /// - Be a valid Stellar contract strkey payload and checksum
+    pub fn validate_contract_id(contract_id: &str) -> PrismResult<()> {
+        if !contract_id.starts_with('C') {
+            return Err(PrismError::InvalidAddress(
+                "Contract ID must start with 'C'".to_string(),
+            ));
+        }
+
+        Contract::from_string(contract_id).map_err(|e| {
+            PrismError::InvalidAddress(format!("Invalid contract ID '{contract_id}': {e}"))
+        })?;
+
+        Ok(())
+    }
+
+    /// Instantiate a contract [`Address`] from a validated contract ID string.
+    pub fn from_contract_id(contract_id: &str) -> PrismResult<Self> {
+        Self::validate_contract_id(contract_id)?;
+        let contract = Contract::from_string(contract_id).map_err(|e| {
+            PrismError::InvalidAddress(format!("Invalid contract ID '{contract_id}': {e}"))
+        })?;
+
+        Ok(Self {
+            bytes: contract.0.to_vec(),
+            address_type: AddressType::Contract,
+        })
+    }
+
     /// Convert to strkey string.
     pub fn to_strkey(&self) -> String {
         match self.address_type {
@@ -104,11 +136,24 @@ impl From<Address> for String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use stellar_strkey::ed25519::PrivateKey;
+
+    fn valid_account_strkey() -> String {
+        PublicKey([1; 32]).to_string()
+    }
+
+    fn valid_contract_strkey() -> String {
+        Contract([2; 32]).to_string()
+    }
+
+    fn valid_private_key_strkey() -> String {
+        PrivateKey([3; 32]).to_string()
+    }
 
     #[test]
     fn test_address_from_string_valid_account() {
-        let s = "GA5W327P3O6PDH4YCWYAW5M36DREB6ZRYNRFCTO7C6XU66OJSXR6X6R6";
-        let res = Address::from_string(s);
+        let s = valid_account_strkey();
+        let res = Address::from_string(&s);
         assert!(res.is_ok());
         let addr = res.unwrap();
         assert_eq!(addr.address_type, AddressType::Account);
@@ -117,8 +162,8 @@ mod tests {
 
     #[test]
     fn test_address_from_string_valid_contract() {
-        let s = "CA3D5YIF3S62FBE6SYO6ALSTCJR3Y3Y0V7SYCLTULV2S0S0S0S0S0S0S";
-        let res = Address::from_string(s);
+        let s = valid_contract_strkey();
+        let res = Address::from_string(&s);
         assert!(res.is_ok());
         let addr = res.unwrap();
         assert_eq!(addr.address_type, AddressType::Contract);
@@ -139,9 +184,8 @@ mod tests {
 
     #[test]
     fn test_address_from_string_unsupported() {
-        // Seed (starts with S)
-        let s = "SA5W327P3O6PDH4YCWYAW5M36DREB6ZRYNRFCTO7C6XU66OJSUSE4NNI";
-        let res = Address::from_string(s);
+        let s = valid_private_key_strkey();
+        let res = Address::from_string(&s);
         assert!(res.is_err());
         match res {
             Err(PrismError::InvalidAddress(msg)) => {
@@ -153,8 +197,11 @@ mod tests {
 
     #[test]
     fn test_address_from_string_corrupted_checksum() {
-        let s = "GA5W327P3O6PDH4YCWYAW5M36DREB6ZRYNRFCTO7C6XU66OJSXR6X6R7"; // Ending changed from R6 to R7
-        let res = Address::from_string(s);
+        let mut s = valid_account_strkey();
+        let last = s.pop().unwrap();
+        s.push(if last == 'A' { 'B' } else { 'A' });
+
+        let res = Address::from_string(&s);
         assert!(res.is_err());
         match res {
             Err(PrismError::InvalidAddress(msg)) => {
@@ -162,5 +209,51 @@ mod tests {
             }
             _ => panic!("Expected InvalidAddress error for corrupted checksum"),
         }
+    }
+
+    #[test]
+    fn test_validate_contract_id_valid() {
+        let s = valid_contract_strkey();
+        let res = Address::validate_contract_id(&s);
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_validate_contract_id_wrong_prefix() {
+        let s = valid_account_strkey();
+        let res = Address::validate_contract_id(&s);
+        assert!(res.is_err());
+        match res {
+            Err(PrismError::InvalidAddress(msg)) => {
+                assert!(msg.contains("must start with 'C'"));
+            }
+            _ => panic!("Expected InvalidAddress error for wrong prefix"),
+        }
+    }
+
+    #[test]
+    fn test_validate_contract_id_malformed() {
+        let mut s = valid_contract_strkey();
+        let last = s.pop().unwrap();
+        s.push(if last == 'A' { 'B' } else { 'A' });
+
+        let res = Address::validate_contract_id(&s);
+        assert!(res.is_err());
+        match res {
+            Err(PrismError::InvalidAddress(msg)) => {
+                assert!(msg.contains("Invalid contract ID"));
+            }
+            _ => panic!("Expected InvalidAddress error for malformed contract id"),
+        }
+    }
+
+    #[test]
+    fn test_from_contract_id_valid() {
+        let s = valid_contract_strkey();
+        let res = Address::from_contract_id(&s);
+        assert!(res.is_ok());
+        let addr = res.unwrap();
+        assert_eq!(addr.address_type, AddressType::Contract);
+        assert_eq!(addr.to_strkey(), s);
     }
 }

--- a/crates/core/src/xdr/codec.rs
+++ b/crates/core/src/xdr/codec.rs
@@ -6,7 +6,7 @@
 use crate::error::{PrismError, PrismResult};
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use stellar_xdr::curr::{
-    LedgerEntry, Limits, ReadXdr, TransactionEnvelope, TransactionMeta, 
+    DiagnosticEvent, LedgerEntry, Limits, ReadXdr, TransactionEnvelope, TransactionMeta, 
     WriteXdr, TransactionResult,
 };
 
@@ -112,6 +112,25 @@ impl XdrCodec for LedgerEntry {
     }
 }
 
+impl XdrCodec for DiagnosticEvent {
+    const TYPE_NAME: &'static str = "DiagnosticEvent";
+
+    fn from_xdr_bytes(bytes: &[u8]) -> PrismResult<Self> {
+        DiagnosticEvent::from_xdr(bytes, Limits::none()).map_err(|e| {
+            PrismError::XdrDecodingFailed {
+                type_name: Self::TYPE_NAME,
+                reason: e.to_string(),
+            }
+        })
+    }
+
+    fn to_xdr_bytes(&self) -> PrismResult<Vec<u8>> {
+        self.to_xdr(Limits::none()).map_err(|e| {
+            PrismError::XdrError(format!("Failed to encode {}: {}", Self::TYPE_NAME, e))
+        })
+    }
+}
+
 // ── Low-level helpers ───────────────────────────────────────────────────────
 
 /// Decode a base64-encoded XDR string to raw bytes.
@@ -171,8 +190,8 @@ mod tests {
     #[test]
     fn test_xdr_codec_round_trip() {
         let envelope = make_test_envelope();
-        let b64 = XdrCodec::to_xdr_base64(&envelope).expect("encode");
-        let decoded = <TransactionEnvelope as XdrCodec>::from_xdr_base64(&b64).expect("decode");
+        let b64 = crate::xdr::codec::XdrCodec::to_xdr_base64(&envelope).expect("encode");
+        let decoded = <TransactionEnvelope as crate::xdr::codec::XdrCodec>::from_xdr_base64(&b64).expect("decode");
         assert_eq!(envelope, decoded);
     }
 
@@ -200,7 +219,7 @@ mod tests {
         ];
         
         let b64 = encode_xdr_base64(&xdr_bytes);
-        let meta = <TransactionMeta as XdrCodec>::from_xdr_base64(&b64).expect("decode V3");
+        let meta = <TransactionMeta as crate::xdr::codec::XdrCodec>::from_xdr_base64(&b64).expect("decode V3");
 
         if let TransactionMeta::V3(v3) = meta {
             assert_eq!(v3.operations.len(), 1);
@@ -224,8 +243,8 @@ mod tests {
         let xdr_bytes = vec![0u8; 20];
         let bytes = encode_xdr_base64(&xdr_bytes);
         
-        let decoded = <TransactionResult as XdrCodec>::from_xdr_base64(&bytes).expect("decode");
-        let encoded = XdrCodec::to_xdr_base64(&decoded).expect("encode");
+        let decoded = <TransactionResult as crate::xdr::codec::XdrCodec>::from_xdr_base64(&bytes).expect("decode");
+        let encoded = crate::xdr::codec::XdrCodec::to_xdr_base64(&decoded).expect("encode");
         
         assert_eq!(bytes, encoded);
     }

--- a/crates/core/src/xdr/codec.rs
+++ b/crates/core/src/xdr/codec.rs
@@ -6,7 +6,8 @@
 use crate::error::{PrismError, PrismResult};
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use stellar_xdr::curr::{
-    LedgerEntry, Limits, ReadXdr, TransactionEnvelope, TransactionMeta, TransactionResult, WriteXdr,
+    LedgerEntry, Limits, ReadXdr, TransactionEnvelope, TransactionMeta, 
+    WriteXdr, TransactionResult,
 };
 
 /// Uniform base64-XDR encode/decode interface for Stellar XDR types.
@@ -96,9 +97,11 @@ impl XdrCodec for LedgerEntry {
     const TYPE_NAME: &'static str = "LedgerEntry";
 
     fn from_xdr_bytes(bytes: &[u8]) -> PrismResult<Self> {
-        LedgerEntry::from_xdr(bytes, Limits::none()).map_err(|e| PrismError::XdrDecodingFailed {
-            type_name: Self::TYPE_NAME,
-            reason: e.to_string(),
+        LedgerEntry::from_xdr(bytes, Limits::none()).map_err(|e| {
+            PrismError::XdrDecodingFailed {
+                type_name: Self::TYPE_NAME,
+                reason: e.to_string(),
+            }
         })
     }
 
@@ -113,9 +116,9 @@ impl XdrCodec for LedgerEntry {
 
 /// Decode a base64-encoded XDR string to raw bytes.
 pub fn decode_xdr_base64(xdr_base64: &str) -> PrismResult<Vec<u8>> {
-    STANDARD
-        .decode(xdr_base64)
-        .map_err(|e| PrismError::XdrError(format!("Base64 decode failed: {}", e)))
+    STANDARD.decode(xdr_base64).map_err(|e| {
+        PrismError::XdrError(format!("Base64 decode failed: {}", e))
+    })
 }
 
 /// Encode raw bytes to a base64 XDR string.
@@ -127,14 +130,14 @@ pub fn encode_xdr_base64(bytes: &[u8]) -> String {
 pub fn decode_tx_hash(hash_hex: &str) -> PrismResult<[u8; 32]> {
     let bytes = hex_decode(hash_hex)
         .map_err(|e| PrismError::XdrError(format!("Invalid tx hash hex: {}", e)))?;
-
+    
     if bytes.len() != 32 {
         return Err(PrismError::XdrError(format!(
             "Transaction hash must be 32 bytes, got {}",
             bytes.len()
         )));
     }
-
+    
     let mut arr = [0u8; 32];
     arr.copy_from_slice(&bytes);
     Ok(arr)
@@ -146,8 +149,8 @@ pub fn decode_tx_hash(hash_hex: &str) -> PrismResult<[u8; 32]> {
 mod tests {
     use super::*;
     use stellar_xdr::curr::{
-        ExtensionPoint, Memo, MuxedAccount, OperationMeta, Preconditions, SequenceNumber,
-        Transaction, TransactionExt, TransactionMetaV3, TransactionV1Envelope, Uint256,
+        Memo, MuxedAccount, Preconditions, SequenceNumber, Transaction, 
+        TransactionExt, TransactionV1Envelope, Uint256,
     };
 
     fn make_test_envelope() -> TransactionEnvelope {
@@ -175,24 +178,34 @@ mod tests {
 
     #[test]
     fn test_transaction_meta_v3_decoding() {
-        let meta = TransactionMeta::V3(TransactionMetaV3 {
-            ext: ExtensionPoint::V0,
-            tx_changes_before: vec![].try_into().expect("empty changes"),
-            operations: vec![OperationMeta {
-                changes: vec![].try_into().expect("empty operation changes"),
-            }]
-            .try_into()
-            .expect("one operation"),
-            tx_changes_after: vec![].try_into().expect("empty changes"),
-            soroban_meta: None,
-        });
-
-        let b64 = XdrCodec::to_xdr_base64(&meta).expect("encode V3");
+        // Minimal TransactionMetaV3 XDR bytes (big-endian).
+        let xdr_bytes: Vec<u8> = vec![
+            0, 0, 0, 3, // V3 discriminant
+            0, 0, 0, 0, // ext = ExtensionPoint::V0
+            0, 0, 0, 0, // txChangesBefore = []
+            0, 0, 0, 1, // operations length = 1
+            0, 0, 0, 0, // OperationMeta.changes = []
+            0, 0, 0, 0, // txChangesAfter = []
+            0, 0, 0, 1, // sorobanMeta present
+            0, 0, 0, 0, // SorobanTransactionMetaExt::V0
+            0, 0, 0, 1, // events length = 1
+            0, 0, 0, 0, // ContractEvent.ext = V0
+            0, 0, 0, 0, // contractId absent
+            0, 0, 0, 1, // type = CONTRACT
+            0, 0, 0, 0, // body discriminant V0
+            0, 0, 0, 0, // topics = []
+            0, 0, 0, 0, // data = ScVal::Void
+            0, 0, 0, 0, // returnValue = ScVal::Void
+            0, 0, 0, 0, // diagnosticEvents = []
+        ];
+        
+        let b64 = encode_xdr_base64(&xdr_bytes);
         let meta = <TransactionMeta as XdrCodec>::from_xdr_base64(&b64).expect("decode V3");
 
         if let TransactionMeta::V3(v3) = meta {
             assert_eq!(v3.operations.len(), 1);
-            assert!(v3.soroban_meta.is_none());
+            let soroban = v3.soroban_meta.expect("soroban_meta");
+            assert_eq!(soroban.events.len(), 1);
         } else {
             panic!("expected V3");
         }
@@ -210,10 +223,10 @@ mod tests {
         // 8 bytes (fee), 4 bytes (code), 4 bytes (results len), 4 bytes (ext)
         let xdr_bytes = vec![0u8; 20];
         let bytes = encode_xdr_base64(&xdr_bytes);
-
+        
         let decoded = <TransactionResult as XdrCodec>::from_xdr_base64(&bytes).expect("decode");
         let encoded = XdrCodec::to_xdr_base64(&decoded).expect("encode");
-
+        
         assert_eq!(bytes, encoded);
     }
 }

--- a/crates/core/src/xdr/codec.rs
+++ b/crates/core/src/xdr/codec.rs
@@ -1,13 +1,13 @@
 //! XDR codec - thin wrapper over `stellar-xdr` with convenience methods.
 //!
 //! Handles serialization/deserialization of transaction envelopes, results,
-//! ledger entries, ScVal, and ScSpecEntry types.
+//! ledger entries, SCVal, and SCSpecEntry types.
 
 use crate::error::{PrismError, PrismResult};
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use stellar_xdr::curr::{
     LedgerEntry, Limits, ReadXdr, TransactionEnvelope, TransactionMeta, 
-    WriteXdr, TransactionResult, ScMap, ScVal, ScSpecEntry,
+    WriteXdr, TransactionResult,
 };
 
 /// Uniform base64-XDR encode/decode interface for Stellar XDR types.
@@ -112,63 +112,6 @@ impl XdrCodec for LedgerEntry {
     }
 }
 
-impl XdrCodec for ScMap {
-    const TYPE_NAME: &'static str = "ScMap";
-
-    fn from_xdr_bytes(bytes: &[u8]) -> PrismResult<Self> {
-        ScMap::from_xdr(bytes, Limits::none()).map_err(|e| {
-            PrismError::XdrDecodingFailed {
-                type_name: Self::TYPE_NAME,
-                reason: e.to_string(),
-            }
-        })
-    }
-
-    fn to_xdr_bytes(&self) -> PrismResult<Vec<u8>> {
-        self.to_xdr(Limits::none()).map_err(|e| {
-            PrismError::XdrError(format!("Failed to encode {}: {}", Self::TYPE_NAME, e))
-        })
-    }
-}
-
-impl XdrCodec for ScVal {
-    const TYPE_NAME: &'static str = "ScVal";
-
-    fn from_xdr_bytes(bytes: &[u8]) -> PrismResult<Self> {
-        ScVal::from_xdr(bytes, Limits::none()).map_err(|e| {
-            PrismError::XdrDecodingFailed {
-                type_name: Self::TYPE_NAME,
-                reason: e.to_string(),
-            }
-        })
-    }
-
-    fn to_xdr_bytes(&self) -> PrismResult<Vec<u8>> {
-        self.to_xdr(Limits::none()).map_err(|e| {
-            PrismError::XdrError(format!("Failed to encode {}: {}", Self::TYPE_NAME, e))
-        })
-    }
-}
-
-impl XdrCodec for ScSpecEntry {
-    const TYPE_NAME: &'static str = "ScSpecEntry";
-
-    fn from_xdr_bytes(bytes: &[u8]) -> PrismResult<Self> {
-        ScSpecEntry::from_xdr(bytes, Limits::none()).map_err(|e| {
-            PrismError::XdrDecodingFailed {
-                type_name: Self::TYPE_NAME,
-                reason: e.to_string(),
-            }
-        })
-    }
-
-    fn to_xdr_bytes(&self) -> PrismResult<Vec<u8>> {
-        self.to_xdr(Limits::none()).map_err(|e| {
-            PrismError::XdrError(format!("Failed to encode {}: {}", Self::TYPE_NAME, e))
-        })
-    }
-}
-
 // ── Low-level helpers ───────────────────────────────────────────────────────
 
 /// Decode a base64-encoded XDR string to raw bytes.
@@ -229,7 +172,7 @@ mod tests {
     fn test_xdr_codec_round_trip() {
         let envelope = make_test_envelope();
         let b64 = XdrCodec::to_xdr_base64(&envelope).expect("encode");
-        let decoded = TransactionEnvelope::from_xdr_base64(&b64).expect("decode");
+        let decoded = <TransactionEnvelope as XdrCodec>::from_xdr_base64(&b64).expect("decode");
         assert_eq!(envelope, decoded);
     }
 
@@ -251,13 +194,13 @@ mod tests {
             0, 0, 0, 1, // type = CONTRACT
             0, 0, 0, 0, // body discriminant V0
             0, 0, 0, 0, // topics = []
-            0, 0, 0, 1, // data = ScVal::Void
-            0, 0, 0, 1, // returnValue = ScVal::Void
+            0, 0, 0, 0, // data = ScVal::Void
+            0, 0, 0, 0, // returnValue = ScVal::Void
             0, 0, 0, 0, // diagnosticEvents = []
         ];
         
         let b64 = encode_xdr_base64(&xdr_bytes);
-        let meta = TransactionMeta::from_xdr_base64(&b64).expect("decode V3");
+        let meta = <TransactionMeta as XdrCodec>::from_xdr_base64(&b64).expect("decode V3");
 
         if let TransactionMeta::V3(v3) = meta {
             assert_eq!(v3.operations.len(), 1);
@@ -281,40 +224,10 @@ mod tests {
         let xdr_bytes = vec![0u8; 20];
         let bytes = encode_xdr_base64(&xdr_bytes);
         
-        let decoded = TransactionResult::from_xdr_base64(&bytes).expect("decode");
+        let decoded = <TransactionResult as XdrCodec>::from_xdr_base64(&bytes).expect("decode");
         let encoded = XdrCodec::to_xdr_base64(&decoded).expect("encode");
         
         assert_eq!(bytes, encoded);
-    }
-
-    #[test]
-    fn test_scmap_round_trip() {
-        let scmap = ScMap(vec![].try_into().unwrap());
-        let b64 = XdrCodec::to_xdr_base64(&scmap).expect("encode");
-        let decoded = ScMap::from_xdr_base64(&b64).expect("decode");
-        assert_eq!(scmap, decoded);
-    }
-
-    #[test]
-    fn test_scval_round_trip() {
-        let scval = ScVal::Void;
-        let b64 = XdrCodec::to_xdr_base64(&scval).expect("encode");
-        let decoded = ScVal::from_xdr_base64(&b64).expect("decode");
-        assert_eq!(scval, decoded);
-    }
-
-    #[test]
-    fn test_scspecentry_round_trip() {
-        use stellar_xdr::curr::ScSpecFunctionV0;
-        let entry = ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
-            doc: "".try_into().unwrap(),
-            name: "test".try_into().unwrap(),
-            inputs: vec![].try_into().unwrap(),
-            outputs: vec![].try_into().unwrap(),
-        });
-        let b64 = XdrCodec::to_xdr_base64(&entry).expect("encode");
-        let decoded = ScSpecEntry::from_xdr_base64(&b64).expect("decode");
-        assert_eq!(entry, decoded);
     }
 }
 

--- a/crates/core/src/xdr/codec.rs
+++ b/crates/core/src/xdr/codec.rs
@@ -6,8 +6,7 @@
 use crate::error::{PrismError, PrismResult};
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use stellar_xdr::curr::{
-    LedgerEntry, Limits, ReadXdr, TransactionEnvelope, TransactionMeta, 
-    WriteXdr, TransactionResult,
+    LedgerEntry, Limits, ReadXdr, TransactionEnvelope, TransactionMeta, TransactionResult, WriteXdr,
 };
 
 /// Uniform base64-XDR encode/decode interface for Stellar XDR types.
@@ -97,11 +96,9 @@ impl XdrCodec for LedgerEntry {
     const TYPE_NAME: &'static str = "LedgerEntry";
 
     fn from_xdr_bytes(bytes: &[u8]) -> PrismResult<Self> {
-        LedgerEntry::from_xdr(bytes, Limits::none()).map_err(|e| {
-            PrismError::XdrDecodingFailed {
-                type_name: Self::TYPE_NAME,
-                reason: e.to_string(),
-            }
+        LedgerEntry::from_xdr(bytes, Limits::none()).map_err(|e| PrismError::XdrDecodingFailed {
+            type_name: Self::TYPE_NAME,
+            reason: e.to_string(),
         })
     }
 
@@ -116,9 +113,9 @@ impl XdrCodec for LedgerEntry {
 
 /// Decode a base64-encoded XDR string to raw bytes.
 pub fn decode_xdr_base64(xdr_base64: &str) -> PrismResult<Vec<u8>> {
-    STANDARD.decode(xdr_base64).map_err(|e| {
-        PrismError::XdrError(format!("Base64 decode failed: {}", e))
-    })
+    STANDARD
+        .decode(xdr_base64)
+        .map_err(|e| PrismError::XdrError(format!("Base64 decode failed: {}", e)))
 }
 
 /// Encode raw bytes to a base64 XDR string.
@@ -130,14 +127,14 @@ pub fn encode_xdr_base64(bytes: &[u8]) -> String {
 pub fn decode_tx_hash(hash_hex: &str) -> PrismResult<[u8; 32]> {
     let bytes = hex_decode(hash_hex)
         .map_err(|e| PrismError::XdrError(format!("Invalid tx hash hex: {}", e)))?;
-    
+
     if bytes.len() != 32 {
         return Err(PrismError::XdrError(format!(
             "Transaction hash must be 32 bytes, got {}",
             bytes.len()
         )));
     }
-    
+
     let mut arr = [0u8; 32];
     arr.copy_from_slice(&bytes);
     Ok(arr)
@@ -149,8 +146,8 @@ pub fn decode_tx_hash(hash_hex: &str) -> PrismResult<[u8; 32]> {
 mod tests {
     use super::*;
     use stellar_xdr::curr::{
-        Memo, MuxedAccount, Preconditions, SequenceNumber, Transaction, 
-        TransactionExt, TransactionV1Envelope, Uint256,
+        ExtensionPoint, Memo, MuxedAccount, OperationMeta, Preconditions, SequenceNumber,
+        Transaction, TransactionExt, TransactionMetaV3, TransactionV1Envelope, Uint256,
     };
 
     fn make_test_envelope() -> TransactionEnvelope {
@@ -178,34 +175,24 @@ mod tests {
 
     #[test]
     fn test_transaction_meta_v3_decoding() {
-        // Minimal TransactionMetaV3 XDR bytes (big-endian).
-        let xdr_bytes: Vec<u8> = vec![
-            0, 0, 0, 3, // V3 discriminant
-            0, 0, 0, 0, // ext = ExtensionPoint::V0
-            0, 0, 0, 0, // txChangesBefore = []
-            0, 0, 0, 1, // operations length = 1
-            0, 0, 0, 0, // OperationMeta.changes = []
-            0, 0, 0, 0, // txChangesAfter = []
-            0, 0, 0, 1, // sorobanMeta present
-            0, 0, 0, 0, // SorobanTransactionMetaExt::V0
-            0, 0, 0, 1, // events length = 1
-            0, 0, 0, 0, // ContractEvent.ext = V0
-            0, 0, 0, 0, // contractId absent
-            0, 0, 0, 1, // type = CONTRACT
-            0, 0, 0, 0, // body discriminant V0
-            0, 0, 0, 0, // topics = []
-            0, 0, 0, 0, // data = ScVal::Void
-            0, 0, 0, 0, // returnValue = ScVal::Void
-            0, 0, 0, 0, // diagnosticEvents = []
-        ];
-        
-        let b64 = encode_xdr_base64(&xdr_bytes);
+        let meta = TransactionMeta::V3(TransactionMetaV3 {
+            ext: ExtensionPoint::V0,
+            tx_changes_before: vec![].try_into().expect("empty changes"),
+            operations: vec![OperationMeta {
+                changes: vec![].try_into().expect("empty operation changes"),
+            }]
+            .try_into()
+            .expect("one operation"),
+            tx_changes_after: vec![].try_into().expect("empty changes"),
+            soroban_meta: None,
+        });
+
+        let b64 = XdrCodec::to_xdr_base64(&meta).expect("encode V3");
         let meta = <TransactionMeta as XdrCodec>::from_xdr_base64(&b64).expect("decode V3");
 
         if let TransactionMeta::V3(v3) = meta {
             assert_eq!(v3.operations.len(), 1);
-            let soroban = v3.soroban_meta.expect("soroban_meta");
-            assert_eq!(soroban.events.len(), 1);
+            assert!(v3.soroban_meta.is_none());
         } else {
             panic!("expected V3");
         }
@@ -223,10 +210,10 @@ mod tests {
         // 8 bytes (fee), 4 bytes (code), 4 bytes (results len), 4 bytes (ext)
         let xdr_bytes = vec![0u8; 20];
         let bytes = encode_xdr_base64(&xdr_bytes);
-        
+
         let decoded = <TransactionResult as XdrCodec>::from_xdr_base64(&bytes).expect("decode");
         let encoded = XdrCodec::to_xdr_base64(&decoded).expect("encode");
-        
+
         assert_eq!(bytes, encoded);
     }
 }


### PR DESCRIPTION

Previously, JSON-RPC errors were flattened into a generic `RpcError(String)`, losing the specific error code provided by the node. This PR introduces a structured way to handle these errors.

## Key Changes

* **`crates/core/src/error.rs`:**
  * Added `JsonRpcError` struct with `code` and `message` fields.
  * Added `PrismError::JsonRpc` variant using the new struct.
* **`crates/core/src/rpc/jsonrpc.rs`:**
  * Removed local `JsonRpcError` definition.
  * Updated response parsing to use the centralized error type.
* **`crates/core/src/rpc/client.rs`:**
  * Updated `getTransaction` and other calls to return `PrismError::JsonRpc` when the node reports a protocol error.

closes #173 