### PR TITLE
feat: implement ArchiveErrorKind and wire into PrismError (#169)

### DIFF
--- a/crates/core/src/archive/mod.rs
+++ b/crates/core/src/archive/mod.rs
@@ -4,7 +4,7 @@
 //! Supports S3/GCS/HTTP backends. Used only for older transactions outside the RPC hot path.
 
 use crate::network::NetworkConfig;
-use crate::error::{PrismError, PrismResult};
+use crate::error::{ArchiveErrorKind, PrismResult};
 
 /// Client for accessing Stellar History Archives.
 pub struct ArchiveClient {
@@ -56,9 +56,11 @@ impl ArchiveClient {
             "Fetching archive checkpoint for ledger {checkpoint_seq}"
         );
 
-        Err(PrismError::ArchiveError(
-            "Archive fetch not yet implemented".to_string(),
-        ))
+        Err(ArchiveErrorKind::FetchFailed {
+            file: format!("checkpoint-{checkpoint_seq}"),
+            reason: "Archive fetch not yet implemented".to_string(),
+        }
+        .into())
     }
 
     /// Fetch a specific ledger entry from the history archives.
@@ -67,9 +69,11 @@ impl ArchiveClient {
         _ledger_sequence: u32,
         _key: &str,
     ) -> PrismResult<Vec<u8>> {
-        Err(PrismError::ArchiveError(
-            "Ledger entry fetch not yet implemented".to_string(),
-        ))
+        Err(ArchiveErrorKind::FetchFailed {
+            file: format!("ledger-entry-{_ledger_sequence}-{_key}"),
+            reason: "Ledger entry fetch not yet implemented".to_string(),
+        }
+        .into())
     }
 }
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -2,20 +2,44 @@
 
 use thiserror::Error;
 
+/// Specific failure kinds for history archive operations.
+#[derive(Debug, Error)]
+pub enum ArchiveErrorKind {
+    /// A fetched archive file did not match its expected checksum.
+    #[error("checksum mismatch for '{file}': expected {expected}, got {actual}")]
+    ChecksumMismatch {
+        file: String,
+        expected: String,
+        actual: String,
+    },
+
+    /// An archive file contained XDR that could not be decoded.
+    #[error("malformed XDR in '{file}': {reason}")]
+    MalformedXdr { file: String, reason: String },
+
+    /// An archive file could not be fetched from any configured backend.
+    #[error("failed to fetch '{file}' from all archive backends: {reason}")]
+    FetchFailed { file: String, reason: String },
+
+    /// An archive file could not be decompressed.
+    #[error("decompression failed for '{file}': {reason}")]
+    DecompressionFailed { file: String, reason: String },
+}
+
 /// Top-level error type for all Prism operations.
 #[derive(Debug, Error)]
 pub enum PrismError {
     /// A network request exceeded the configured timeout duration.
     #[error("RPC request timed out after {timeout_secs}s (method: {method})")]
     NetworkTimeout { method: String, timeout_secs: u64 },
-    
+
     /// Error communicating with the Soroban RPC endpoint.
     #[error("RPC error: {0}")]
     RpcError(String),
-    
+
     /// Error fetching or parsing history archive data.
     #[error("Archive error: {0}")]
-    ArchiveError(String),
+    ArchiveError(#[from] ArchiveErrorKind),
     
     /// Error decoding XDR data.
     #[error("XDR error: {0}")]


### PR DESCRIPTION
@Emrys02 

- Add ArchiveErrorKind enum with ChecksumMismatch, MalformedXdr, FetchFailed, and DecompressionFailed variants
- Replace PrismError::ArchiveError(String) with structured ArchiveError(#[from] ArchiveErrorKind) for automatic conversion
- Update archive module to use ArchiveErrorKind directly

closes #169 