### PR TITLE
feat(core): define HostError enum as central decode engine type

### DIFF
--- a/crates/core/src/decode/host_error.rs
+++ b/crates/core/src/decode/host_error.rs
@@ -1,30 +1,72 @@
-//! Host error classifier.
+//! Host error types.
 //!
-//! Parses error category + code from TransactionResult XDR and classifies
-//! into known error families using the taxonomy database.
+//! `HostError` is the central type the decode engine works with. It covers
+//! every Soroban host error category, contract-specific errors, and an
+//! `Unknown` variant for forward compatibility.
 
-use crate::taxonomy::schema::ErrorCategory;
+use serde::Serialize;
+
 use crate::error::{PrismError, PrismResult};
+use crate::taxonomy::schema::ErrorCategory;
+
+/// Every Soroban host error category, plus contract-specific and unknown variants.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(tag = "category", rename_all = "snake_case")]
+pub enum HostError {
+    Budget { code: u32 },
+    Storage { code: u32 },
+    Auth { code: u32 },
+    Context { code: u32 },
+    Value { code: u32 },
+    Object { code: u32 },
+    Crypto { code: u32 },
+    Contract { code: u32 },
+    Wasm { code: u32 },
+    Events { code: u32 },
+    /// Error defined by a specific deployed contract.
+    ContractSpecific {
+        contract_id: Option<String>,
+        code: u32,
+    },
+    /// Unrecognised error — preserved for forward compatibility.
+    Unknown { type_code: u32, sub_code: u32 },
+}
+
+impl HostError {
+    /// Human-readable category name.
+    pub fn category_name(&self) -> &str {
+        match self {
+            Self::Budget { .. } => "Budget",
+            Self::Storage { .. } => "Storage",
+            Self::Auth { .. } => "Auth",
+            Self::Context { .. } => "Context",
+            Self::Value { .. } => "Value",
+            Self::Object { .. } => "Object",
+            Self::Crypto { .. } => "Crypto",
+            Self::Contract { .. } => "Contract",
+            Self::Wasm { .. } => "Wasm",
+            Self::Events { .. } => "Events",
+            Self::ContractSpecific { .. } => "ContractSpecific",
+            Self::Unknown { .. } => "Unknown",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers kept from the original file
+// ---------------------------------------------------------------------------
 
 /// Classified error information extracted from a transaction result.
 #[derive(Debug, Clone)]
 pub struct ClassifiedError {
-    /// Error category.
     pub category: ErrorCategory,
-    /// Numeric error code.
     pub error_code: u32,
-    /// Whether this is a contract-defined error (vs host error).
     pub is_contract_error: bool,
-    /// Contract ID if this is a contract error.
     pub contract_id: Option<String>,
-    /// Raw error data for further processing.
     pub raw_data: serde_json::Value,
 }
 
 /// Classify the error from a transaction result JSON.
-///
-/// Extracts the error category, code, and determines whether it's a host error
-/// or a contract-defined error.
 pub fn classify_error(tx_data: &serde_json::Value) -> PrismResult<ClassifiedError> {
     let status = tx_data
         .get("status")
@@ -36,7 +78,6 @@ pub fn classify_error(tx_data: &serde_json::Value) -> PrismResult<ClassifiedErro
             "Transaction succeeded — no error to classify".to_string(),
         ));
     }
-
 
     Ok(ClassifiedError {
         category: ErrorCategory::Contract,
@@ -69,12 +110,52 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_category_name() {
+        assert_eq!(HostError::Budget { code: 1 }.category_name(), "Budget");
+        assert_eq!(HostError::Storage { code: 2 }.category_name(), "Storage");
+        assert_eq!(HostError::Auth { code: 3 }.category_name(), "Auth");
+        assert_eq!(HostError::Context { code: 0 }.category_name(), "Context");
+        assert_eq!(HostError::Value { code: 0 }.category_name(), "Value");
+        assert_eq!(HostError::Object { code: 0 }.category_name(), "Object");
+        assert_eq!(HostError::Crypto { code: 0 }.category_name(), "Crypto");
+        assert_eq!(HostError::Contract { code: 0 }.category_name(), "Contract");
+        assert_eq!(HostError::Wasm { code: 0 }.category_name(), "Wasm");
+        assert_eq!(HostError::Events { code: 0 }.category_name(), "Events");
+        assert_eq!(
+            HostError::ContractSpecific { contract_id: None, code: 42 }.category_name(),
+            "ContractSpecific"
+        );
+        assert_eq!(
+            HostError::Unknown { type_code: 99, sub_code: 1 }.category_name(),
+            "Unknown"
+        );
+    }
+
+    #[test]
+    fn test_serialize_to_json() {
+        let err = HostError::ContractSpecific {
+            contract_id: Some("CABC123".to_string()),
+            code: 3,
+        };
+        let json = serde_json::to_string(&err).unwrap();
+        assert!(json.contains("\"category\":\"contract_specific\""));
+        assert!(json.contains("\"code\":3"));
+        assert!(json.contains("CABC123"));
+    }
+
+    #[test]
+    fn test_unknown_variant() {
+        let err = HostError::Unknown { type_code: 7, sub_code: 255 };
+        let json = serde_json::to_value(&err).unwrap();
+        assert_eq!(json["category"], "unknown");
+        assert_eq!(json["type_code"], 7);
+        assert_eq!(json["sub_code"], 255);
+    }
+
+    #[test]
     fn test_parse_error_category() {
         assert_eq!(parse_error_category("budget"), Some(ErrorCategory::Budget));
-        assert_eq!(
-            parse_error_category("STORAGE"),
-            Some(ErrorCategory::Storage)
-        );
-        assert_eq!(parse_error_category("unknown"), None);
+        assert_eq!(parse_error_category("STORAGE"), Some(ErrorCategory::Storage));
+        assert_eq!(parse_error_category("unknown_xyz"), None);
     }
 }


### PR DESCRIPTION
Define HostError enum as the central decode engine type
  
  Introduces the HostError enum in crates/core/src/decode/host_error.rs as the foundational type
  for Prism's decode engine. This enum provides a strongly-typed, serializable representation of
  every Soroban host error category.
  
  Changes
  
  - Added HostError enum with one variant per Soroban error category (Budget, Storage, Auth,
  Context, Value, Object, Crypto, Contract, Wasm, Events), each carrying a u32 subcode
  - Added ContractSpecific { contract_id: Option<String>, code: u32 } for errors originating from
  deployed contracts
  - Added Unknown { type_code: u32, sub_code: u32 } for forward compatibility with future error
  codes
  - Derives Debug, Clone, PartialEq, Serialize — serializes to tagged JSON via serde
  - Exposes category_name(&self) -> &str for human-readable category identification
  - Preserved existing ClassifiedError, classify_error, and parse_error_category helpers
  - Added unit tests covering serialization shape, category_name correctness, and all variant
  paths
  
  Testing
  
  All tests pass locally. Coverage includes JSON serialization of ContractSpecific and Unknown
   variants, and full category_name coverage across all 12 variants.

close #192 