### PR TITLE
Implement Debug and Serialize for all shared types (#160)

### DIFF
--- a/crates/core/src/rpc/metrics.rs
+++ b/crates/core/src/rpc/metrics.rs
@@ -22,6 +22,7 @@
 //!
 //! [prom-fmt]: https://prometheus.io/docs/instrumenting/exposition_formats/
 
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
 
@@ -36,7 +37,7 @@ const BUCKETS: &[f64] = &[
 
 
 /// Cumulative histogram for a single `(method, outcome)` combination.
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 struct Histogram {
     /// Cumulative count per bucket (one entry per [`BUCKETS`] bound).
     ///
@@ -108,7 +109,7 @@ impl Histogram {
 /// Keyed by `"<method>:<outcome>"` where *outcome* is either `"success"` or
 /// `"error"`. This lets callers distinguish successful RPC calls from failed
 /// ones in dashboards and alerts.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct RpcMetricsRegistry {
     histograms: HashMap<String, Histogram>,
 }

--- a/crates/core/src/types/address.rs
+++ b/crates/core/src/types/address.rs
@@ -1,5 +1,6 @@
 //! Address types for Stellar accounts and contracts.
 
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use stellar_strkey::{ed25519::PublicKey, Contract, Strkey};
 
@@ -8,7 +9,7 @@ use crate::error::{PrismError, PrismResult};
 /// Represents a Stellar address (account or contract).
 ///
 /// Internally stores the raw bytes, but displays as the standard strkey format.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Address {
     /// The raw bytes of the address.
     pub bytes: Vec<u8>,
@@ -17,7 +18,7 @@ pub struct Address {
 }
 
 /// The type of Stellar address.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum AddressType {
     /// Account public key (starts with 'G').
     Account,


### PR DESCRIPTION
Closes #160

---

- Add Serialize and Deserialize to Address and AddressType in types/address.rs
- Add Serialize and Deserialize to Histogram and RpcMetricsRegistry in rpc/metrics.rs
- All other types already had Debug and Serialize traits implemented