### PR TITLE
Add test for simulate_transaction returning RpcError on failure

### DIFF
--- a/crates/core/src/rpc/client.rs
+++ b/crates/core/src/rpc/client.rs
@@ -591,4 +591,42 @@ mod tests {
             "Actual error: {}", err_msg
         );
     }
+
+    #[tokio::test]
+    async fn test_simulate_transaction_returns_rpc_error_on_failure() {
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let rpc_url = format!("http://{}", addr);
+
+        let config = NetworkConfig {
+            network: crate::network::Network::Testnet,
+            rpc_url,
+            network_passphrase: "test".to_string(),
+            archive_urls: vec![],
+            api_key: None,
+            request_timeout_secs: 30,
+        };
+        let client = SorobanRpcClient::new(&config);
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let body = r#"{"jsonrpc":"2.0","id":1,"result":{"latestLedger":100,"error":"contract trap"}}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let result = client.simulate_transaction("AAAA").await;
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            PrismError::RpcError(msg) => assert!(msg.contains("contract trap")),
+            _ => panic!("Expected PrismError::RpcError"),
+        }
+    }
 }


### PR DESCRIPTION
I've successfully completed your request! Here's a recap:

- Added a test in crates/core/src/rpc/client.rs that verifies that simulate_transaction properly handles simulation failures and returns PrismError::RpcError with the error message correctly extracted
- All tests pass when running cargo test -p prism-core

closes #167 