### PR TITLE
feat: Map Budget error subcodes to detailed descriptions and severities

### DIFF
--- a/crates/core/src/decode/host_error.rs
+++ b/crates/core/src/decode/host_error.rs
@@ -56,9 +56,12 @@ impl HostError {
     /// developer reads when diagnosing a failed transaction.
     pub fn summary(&self) -> String {
         match self {
-            Self::Budget { code } => match code {
-                0 => "CPU budget exceeded: the transaction ran out of CPU instructions before completing execution.".to_string(),
-                _ => format!("Budget error (code {code}): the transaction exceeded an allocated resource budget."),
+            Self::Budget { code } => {
+                if let Some(detail) = crate::decode::mappings::budget::lookup(*code) {
+                    detail.summary.to_string()
+                } else {
+                    format!("Budget error (code {code}): the transaction exceeded an allocated resource budget.")
+                }
             },
             Self::Storage { code } => match code {
                 0 => "Storage access denied: the contract tried to read or write a ledger entry not declared in the transaction footprint.".to_string(),

--- a/crates/core/src/decode/mappings/budget.rs
+++ b/crates/core/src/decode/mappings/budget.rs
@@ -1,0 +1,90 @@
+//! Budget error mappings.
+//!
+//! This module keeps the Budget category's human-readable decoding details in a
+//! compact, testable form for callers that need direct code-to-summary lookup.
+
+use crate::types::report::Severity;
+
+/// Severity mapping specific to Budget errors.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ErrorSeverity {
+    Critical,
+    Error,
+    Warning,
+    Info,
+}
+
+impl From<ErrorSeverity> for Severity {
+    fn from(sev: ErrorSeverity) -> Self {
+        match sev {
+            ErrorSeverity::Critical => Severity::Fatal,
+            ErrorSeverity::Error => Severity::Error,
+            ErrorSeverity::Warning => Severity::Warning,
+            ErrorSeverity::Info => Severity::Info,
+        }
+    }
+}
+
+/// Human-readable Budget error detail.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BudgetErrorDetail {
+    /// Numeric Budget subcode.
+    pub code: u32,
+    /// Canonical error name.
+    pub name: &'static str,
+    /// Short explanation of the failure.
+    pub summary: &'static str,
+    /// Severity to surface in diagnostics.
+    pub severity: ErrorSeverity,
+}
+
+/// Complete Budget error mapping table.
+pub const BUDGET_ERROR_DETAILS: &[BudgetErrorDetail] = &[
+    BudgetErrorDetail {
+        code: 0,
+        name: "CPUExceeded",
+        summary: "CPU budget exceeded: the transaction ran out of CPU instructions before completing execution.",
+        severity: ErrorSeverity::Critical,
+    },
+    BudgetErrorDetail {
+        code: 8,
+        name: "ExceededLimit",
+        summary: "The transaction exceeded an allocated resource limit.",
+        severity: ErrorSeverity::Error,
+    },
+    BudgetErrorDetail {
+        code: 1,
+        name: "InsufficientInstructions",
+        summary: "The transaction did not have enough CPU instructions allocated.",
+        severity: ErrorSeverity::Critical,
+    },
+    BudgetErrorDetail {
+        code: 2,
+        name: "InsufficientMemory",
+        summary: "The transaction did not have enough memory allocated.",
+        severity: ErrorSeverity::Critical,
+    },
+];
+
+/// Look up a single Budget error detail by subcode.
+pub fn lookup(code: u32) -> Option<&'static BudgetErrorDetail> {
+    BUDGET_ERROR_DETAILS.iter().find(|detail| detail.code == code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookup_returns_cpu_exceeded_detail() {
+        let detail = lookup(0).expect("cpu exceeded detail");
+        assert_eq!(detail.name, "CPUExceeded");
+        assert!(detail.summary.contains("CPU instructions"));
+    }
+
+    #[test]
+    fn table_covers_known_budget_codes() {
+        assert_eq!(BUDGET_ERROR_DETAILS.len(), 4);
+        assert!(lookup(99).is_none());
+    }
+}

--- a/crates/core/src/decode/mappings/mod.rs
+++ b/crates/core/src/decode/mappings/mod.rs
@@ -1,4 +1,5 @@
 //! Category-specific decode mappings.
 
 pub mod auth;
+pub mod budget;
 pub mod storage;


### PR DESCRIPTION
This PR implements the mapping for Budget category error subcodes, resolving issue #195. Budget errors (which fire when a transaction exceeds its allocated CPU, memory, or other metered resources) are now explicitly mapped so Prism can clearly distinguish between different resource exhaustion failures (e.g., running out of CPU vs. memory).

## Changes
- **New Mapping Module**: Created `crates/core/src/decode/mappings/budget.rs` to house the budget mapping logic.
- **Budget Definitions**: Introduced the `BudgetErrorDetail` struct and an `ErrorSeverity` enum (`Critical`, `Error`, `Warning`, `Info`) to properly categorize failures.
- **Subcode Mappings**: Added explicit code-to-summary mappings for known budget limits (`ExceededLimit`, `InsufficientInstructions`, and `InsufficientMemory`).
- **Decoding Integration**: Refactored `HostError::summary()` in `crates/core/src/decode/host_error.rs` to route Budget errors through the new `budget::lookup` function.
- **Forward Compatibility**: Unrecognized codes seamlessly fall back to a dynamically formatted string (e.g., `Budget error (code {code}): ...`), ensuring Prism doesn't break on future Soroban protocol updates.

Closes #195 
