### PR TITLE
feat: add DecodeContext with builder pattern

### DIFF
--- a/crates/cli/src/commands/inspect.rs
+++ b/crates/cli/src/commands/inspect.rs
@@ -2,6 +2,7 @@
 
 use clap::Args;
 use prism_core::types::config::NetworkConfig;
+use prism_core::{DecodeContextBuilder, OutputFormat};
 
 #[derive(Args)]
 pub struct InspectArgs {
@@ -19,13 +20,17 @@ pub async fn run(
     output_format: &str,
     save: Option<&str>,
 ) -> anyhow::Result<()> {
+    let ctx = DecodeContextBuilder::from(network)
+        .output_format(OutputFormat::from_str(output_format))
+        .build();
+
     let spinner = indicatif::ProgressBar::new_spinner();
     spinner.set_message("Fetching and decoding transaction...");
     spinner.enable_steady_tick(std::time::Duration::from_millis(100));
 
     let reports = prism_core::decode::decode_transaction_with_op_filter(
         &args.tx_hash,
-        network,
+        &ctx,
         args.op_index,
     )
     .await?;

--- a/crates/core/src/decode/contract_error.rs
+++ b/crates/core/src/decode/contract_error.rs
@@ -1,5 +1,6 @@
 
 
+use crate::decode::decode_context::DecodeContext;
 use crate::error::{PrismError, PrismResult};
 use crate::spec::decoder;
 use crate::types::address::Address;
@@ -7,6 +8,14 @@ use crate::types::config::NetworkConfig;
 use crate::types::report::ContractErrorInfo;
 
 pub async fn resolve(
+    contract_id: &str,
+    error_code: u32,
+    ctx: &DecodeContext,
+) -> PrismResult<ContractErrorInfo> {
+    resolve_with_network(contract_id, error_code, &ctx.network).await
+}
+
+async fn resolve_with_network(
     contract_id: &str,
     error_code: u32,
     network: &NetworkConfig,

--- a/crates/core/src/decode/decode_context.rs
+++ b/crates/core/src/decode/decode_context.rs
@@ -1,0 +1,136 @@
+use crate::network::config::{Network, NetworkConfig};
+
+/// Output format for diagnostic reports.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum OutputFormat {
+    #[default]
+    Human,
+    Json,
+    Compact,
+    Short,
+}
+
+impl OutputFormat {
+    pub fn from_str(s: &str) -> Self {
+        match s {
+            "json" => Self::Json,
+            "compact" => Self::Compact,
+            "short" => Self::Short,
+            _ => Self::Human,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Human => "human",
+            Self::Json => "json",
+            Self::Compact => "compact",
+            Self::Short => "short",
+        }
+    }
+}
+
+/// Runtime configuration threaded through the entire decode pipeline.
+///
+/// Build with [`DecodeContext::builder`] and pass by reference to every analyzer.
+#[derive(Debug, Clone)]
+pub struct DecodeContext {
+    pub network: NetworkConfig,
+    pub verbosity: u8,
+    pub output_format: OutputFormat,
+}
+
+impl DecodeContext {
+    /// Start building a [`DecodeContext`].
+    pub fn builder() -> DecodeContextBuilder {
+        DecodeContextBuilder::default()
+    }
+}
+
+/// Builder for [`DecodeContext`].
+#[derive(Debug, Default)]
+pub struct DecodeContextBuilder {
+    network: Option<NetworkConfig>,
+    verbosity: u8,
+    output_format: OutputFormat,
+}
+
+impl DecodeContextBuilder {
+    pub fn network(mut self, network: NetworkConfig) -> Self {
+        self.network = Some(network);
+        self
+    }
+
+    pub fn verbosity(mut self, verbosity: u8) -> Self {
+        self.verbosity = verbosity;
+        self
+    }
+
+    pub fn output_format(mut self, format: OutputFormat) -> Self {
+        self.output_format = format;
+        self
+    }
+
+    pub fn build(self) -> DecodeContext {
+        DecodeContext {
+            network: self.network.unwrap_or_else(NetworkConfig::testnet),
+            verbosity: self.verbosity,
+            output_format: self.output_format,
+        }
+    }
+}
+
+impl From<&NetworkConfig> for DecodeContextBuilder {
+    fn from(network: &NetworkConfig) -> Self {
+        Self::default().network(network.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builder_defaults_to_testnet() {
+        let ctx = DecodeContext::builder().build();
+        assert_eq!(ctx.network.network, Network::Testnet);
+        assert_eq!(ctx.verbosity, 0);
+        assert_eq!(ctx.output_format, OutputFormat::Human);
+    }
+
+    #[test]
+    fn builder_sets_all_fields() {
+        let ctx = DecodeContext::builder()
+            .network(NetworkConfig::mainnet())
+            .verbosity(2)
+            .output_format(OutputFormat::Json)
+            .build();
+
+        assert_eq!(ctx.network.network, Network::Mainnet);
+        assert_eq!(ctx.verbosity, 2);
+        assert_eq!(ctx.output_format, OutputFormat::Json);
+    }
+
+    #[test]
+    fn output_format_roundtrip() {
+        for (s, expected) in [
+            ("human", OutputFormat::Human),
+            ("json", OutputFormat::Json),
+            ("compact", OutputFormat::Compact),
+            ("short", OutputFormat::Short),
+            ("unknown", OutputFormat::Human),
+        ] {
+            assert_eq!(OutputFormat::from_str(s), expected);
+            if s != "unknown" {
+                assert_eq!(expected.as_str(), s);
+            }
+        }
+    }
+
+    #[test]
+    fn builder_from_network_config_ref() {
+        let network = NetworkConfig::mainnet();
+        let ctx = DecodeContextBuilder::from(&network).build();
+        assert_eq!(ctx.network.network, Network::Mainnet);
+    }
+}


### PR DESCRIPTION
Closes #233 

## Summary

Adds a `DecodeContext` struct that carries all runtime configuration — network, RPC URL (via `NetworkConfig`), verbosity level, and output format — through the entire decode pipeline. Eliminates hardcoded values and global state in analyzers.

## Changes

- **`crates/core/src/decode/decode_context.rs`** (new): `DecodeContext` struct, `DecodeContextBuilder` with `From<&NetworkConfig>` convenience impl, and `OutputFormat` enum (human / json / compact / short).
- **`crates/core/src/decode/mod.rs`**: `decode_transaction` and `decode_transaction_with_op_filter` now accept `&DecodeContext` instead of `&NetworkConfig`. Re-exports the three new types.
- **`crates/core/src/decode/contract_error.rs`**: `resolve` accepts `&DecodeContext`; delegates to the private `resolve_with_network` for the actual network call.
- **`crates/core/src/lib.rs`**: Exports `DecodeContext`, `DecodeContextBuilder`, `OutputFormat`.
- **`crates/cli/src/commands/decode.rs`**: Builds `DecodeContext` from parsed CLI args and passes `&ctx` down.
- **`crates/cli/src/commands/inspect.rs`**: Same treatment as decode.

## What was tested

- Manual code review for type and borrow-checker correctness.
- No global state or hardcoded network values remain in the decode pipeline; all configuration flows through `DecodeContext`.