### PR TITLE
feat: support decoding multi-operation Stellar transactions

### DIFF
--- a/crates/cli/src/commands/decode.rs
+++ b/crates/cli/src/commands/decode.rs
@@ -46,7 +46,7 @@ pub async fn run(
     // Print each report; include operation index header when multiple reports
     for (i, report) in reports.iter().enumerate() {
         if reports.len() > 1 {
-            println!("\n=== Operation {} ===", i);
+            println!("\n=== Operation {} ===", i + 1);
         }
         crate::output::print_diagnostic_report(report, effective_output)?;
     }

--- a/crates/cli/src/commands/decode.rs
+++ b/crates/cli/src/commands/decode.rs
@@ -21,8 +21,10 @@ pub async fn run(
 ) -> anyhow::Result<()> {
     let effective_output = if args.short { "short" } else { output_format };
 
-    let report = if args.raw {
-        build_raw_xdr_report(&args.tx_hash)?
+    // Decode transaction, handling possible multiple operations
+    let reports = if args.raw {
+        // Raw XDR decoding yields a single report
+        vec![build_raw_xdr_report(&args.tx_hash)?]
     } else {
         let spinner = indicatif::ProgressBar::new_spinner();
         spinner.set_message(format!(
@@ -31,15 +33,26 @@ pub async fn run(
         ));
         spinner.enable_steady_tick(std::time::Duration::from_millis(100));
 
-        let report = prism_core::decode::decode_transaction(&args.tx_hash, network).await?;
+        let reports = prism_core::decode::decode_transaction_with_op_filter(
+            &args.tx_hash,
+            network,
+            None,
+        )
+        .await?;
         spinner.finish_and_clear();
-        report
+        reports
     };
 
-    crate::output::print_diagnostic_report(&report, effective_output)?;
+    // Print each report; include operation index header when multiple reports
+    for (i, report) in reports.iter().enumerate() {
+        if reports.len() > 1 {
+            println!("\n=== Operation {} ===", i);
+        }
+        crate::output::print_diagnostic_report(report, effective_output)?;
+    }
 
     if let Some(path) = save {
-        let json = serde_json::to_string_pretty(&report)?;
+        let json = serde_json::to_string_pretty(&reports)?;
         std::fs::write(path, &json)
             .map_err(|e| anyhow::anyhow!("Failed to write save file '{path}': {e}"))?;
         eprintln!("Saved report to {path}");

--- a/crates/cli/src/commands/inspect.rs
+++ b/crates/cli/src/commands/inspect.rs
@@ -32,9 +32,13 @@ pub async fn run(
 
     spinner.finish_and_clear();
 
-    crate::output::print_diagnostic_report(&report, output_format)?;
-
-
+    // Print each report with operation index label
+    for (i, report) in reports.iter().enumerate() {
+        if reports.len() > 1 {
+            println!("\n=== Operation {} ===", i + 1);
+        }
+        crate::output::print_diagnostic_report(report, output_format)?;
+    }
 
     if let Some(path) = save {
         let json = serde_json::to_string_pretty(&reports)?;

--- a/crates/cli/src/commands/inspect.rs
+++ b/crates/cli/src/commands/inspect.rs
@@ -26,7 +26,7 @@ pub async fn run(
     spinner.set_message("Fetching and decoding transaction...");
     spinner.enable_steady_tick(std::time::Duration::from_millis(100));
 
-    let report = prism_core::decode::decode_transaction_with_op_filter(
+    let reports = prism_core::decode::decode_transaction_with_op_filter(
         &args.tx_hash,
         network,
         args.op_index,
@@ -35,50 +35,47 @@ pub async fn run(
 
     spinner.finish_and_clear();
 
-    crate::output::print_diagnostic_report(&report, output_format)?;
-
-    if args.fee_stats
-        && matches!(
-            crate::output::OutputMode::parse(output_format),
-            crate::output::OutputMode::Human
-        )
-    {
-        let fee_context = report.transaction_context.as_ref().map(|ctx| &ctx.fee);
-
-        let bid_fee: Option<i64> = None;
-        let resource_fee = fee_context.map(|fee| fee.resource_fee);
-        let total_charged_fee =
-            fee_context.and_then(|fee| fee.inclusion_fee.checked_add(fee.resource_fee));
-        let inclusion_fee = match (total_charged_fee, resource_fee) {
-            (Some(charged), Some(resource)) => charged.checked_sub(resource),
-            _ => None,
-        };
-        let surge = match (total_charged_fee, bid_fee) {
-            (Some(charged), Some(bid)) => Some(charged > bid),
-            _ => None,
-        };
-
-        let format_fee = |value: Option<i64>| match value {
-            Some(v) => format!("{v} stroops"),
-            None => "N/A".to_string(),
-        };
-        let format_surge = |value: Option<bool>| match value {
-            Some(true) => "Yes",
-            Some(false) => "No",
-            None => "N/A",
-        };
-
-        println!();
-        println!("FEE BREAKDOWN");
-        println!("Bid Fee: {}", format_fee(bid_fee));
-        println!("Total Charged Fee: {}", format_fee(total_charged_fee));
-        println!("Resource Fee: {}", format_fee(resource_fee));
-        println!("Inclusion Fee: {}", format_fee(inclusion_fee));
-        println!("Surge: {}", format_surge(surge));
+    // Print each report with operation index label
+    for (i, report) in reports.iter().enumerate() {
+        if reports.len() > 1 {
+            println!("\n=== Operation {} ===", i);
+        }
+        crate::output::print_diagnostic_report(report, output_format)?;
+        // Fee stats are only meaningful for the first report (transaction-level)
+        if i == 0 && args.fee_stats && matches!(crate::output::OutputMode::parse(output_format), crate::output::OutputMode::Human) {
+            let fee_context = report.transaction_context.as_ref().map(|ctx| &ctx.fee);
+            let bid_fee: Option<i64> = None;
+            let resource_fee = fee_context.map(|fee| fee.resource_fee);
+            let total_charged_fee = fee_context.and_then(|fee| fee.inclusion_fee.checked_add(fee.resource_fee));
+            let inclusion_fee = match (total_charged_fee, resource_fee) {
+                (Some(charged), Some(resource)) => charged.checked_sub(resource),
+                _ => None,
+            };
+            let surge = match (total_charged_fee, bid_fee) {
+                (Some(charged), Some(bid)) => Some(charged > bid),
+                _ => None,
+            };
+            let format_fee = |value: Option<i64>| match value {
+                Some(v) => format!("{v} stroops"),
+                None => "N/A".to_string(),
+            };
+            let format_surge = |value: Option<bool>| match value {
+                Some(true) => "Yes",
+                Some(false) => "No",
+                None => "N/A",
+            };
+            println!();
+            println!("FEE BREAKDOWN");
+            println!("Bid Fee: {}", format_fee(bid_fee));
+            println!("Total Charged Fee: {}", format_fee(total_charged_fee));
+            println!("Resource Fee: {}", format_fee(resource_fee));
+            println!("Inclusion Fee: {}", format_fee(inclusion_fee));
+            println!("Surge: {}", format_surge(surge));
+        }
     }
 
     if let Some(path) = save {
-        let json = serde_json::to_string_pretty(&report)?;
+        let json = serde_json::to_string_pretty(&reports)?;
         std::fs::write(path, &json)
             .map_err(|e| anyhow::anyhow!("Failed to write save file '{path}': {e}"))?;
         eprintln!("Saved report to {path}");

--- a/crates/core/src/decode/mod.rs
+++ b/crates/core/src/decode/mod.rs
@@ -1,5 +1,4 @@
 
-
 pub mod context;
 pub mod contract_error;
 pub mod diagnostic;
@@ -44,7 +43,7 @@ fn filter_transaction_by_operation(
 pub async fn decode_transaction(
     tx_hash: &str,
     network: &crate::types::config::NetworkConfig,
-) -> PrismResult<DiagnosticReport> {
+) -> PrismResult<Vec<DiagnosticReport>> {
     decode_transaction_with_op_filter(tx_hash, network, None).await
 }
 
@@ -52,35 +51,58 @@ pub async fn decode_transaction_with_op_filter(
     tx_hash: &str,
     network: &crate::types::config::NetworkConfig,
     op_index: Option<usize>,
-) -> PrismResult<DiagnosticReport> {
+) -> PrismResult<Vec<DiagnosticReport>> {
     let rpc = crate::rpc::SorobanRpcClient::new(network);
     let tx_data = rpc.get_transaction(tx_hash).await?;
-    let mut tx_data = serde_json::to_value(tx_data)
+    let base_tx_data = serde_json::to_value(tx_data)
         .map_err(|e| crate::error::PrismError::Internal(e.to_string()))?;
 
-    if let Some(index) = op_index {
-        filter_transaction_by_operation(&mut tx_data, index)?;
-    }
-
-    let error_info = host_error::classify_error(&tx_data)?;
-
-    let mut report = report::build_report(&error_info)?;
-
-    if error_info.is_contract_error {
-        if let Ok(contract_info) = contract_error::resolve(
-            &error_info.contract_id.unwrap_or_default(),
-            error_info.error_code,
-            network,
-        )
-        .await
-        {
-            report.contract_error = Some(contract_info);
+    // Decode the envelope XDR to determine the number of operations in the transaction.
+    let num_ops = if let Some(envelope_str) = base_tx_data.get("envelopeXdr").and_then(|v| v.as_str()) {
+        // Use the XDR codec to parse the envelope.
+        let envelope = <stellar_xdr::curr::TransactionEnvelope as crate::xdr::codec::XdrCodec>::from_xdr_base64(envelope_str)
+            .map_err(|e| crate::error::PrismError::Internal(format!("Failed to decode envelope XDR: {}", e)))?;
+        match envelope {
+            stellar_xdr::curr::TransactionEnvelope::Tx(v1) => v1.tx.operations.len(),
+            stellar_xdr::curr::TransactionEnvelope::TxFeeBump(fb) => {
+                // Fee bump transaction contains an inner transaction with its own operations.
+                fb.tx.fee_bump_op.operations.len()
+            }
         }
+    } else {
+        // Fallback to a single operation if envelope missing
+        1
+    };
+
+    let mut reports = Vec::new();
+    let indices = match op_index {
+        Some(i) => vec![i],
+        None => (0..num_ops).collect(),
+    };
+
+    for i in indices {
+        let mut tx_data = base_tx_data.clone();
+        filter_transaction_by_operation(&mut tx_data, i)?;
+
+        let error_info = host_error::classify_error(&tx_data)?;
+        let mut report = report::build_report(&error_info)?;
+
+        if error_info.is_contract_error {
+            if let Ok(contract_info) = contract_error::resolve(
+                &error_info.contract_id.unwrap_or_default(),
+                error_info.error_code,
+                network,
+            )
+            .await
+            {
+                report.contract_error = Some(contract_info);
+            }
+        }
+
+        diagnostic::enrich_report(&mut report, &tx_data)?;
+        context::enrich_report(&mut report, &tx_data)?;
+        reports.push(report);
     }
 
-    diagnostic::enrich_report(&mut report, &tx_data)?;
-
-    context::enrich_report(&mut report, &tx_data)?;
-
-    Ok(report)
+    Ok(reports)
 }

--- a/crates/core/src/decode/mod.rs
+++ b/crates/core/src/decode/mod.rs
@@ -15,7 +15,7 @@ pub use walker::{
 use crate::error::{PrismError, PrismResult};
 use crate::types::report::DiagnosticReport;
 use crate::xdr::codec::XdrCodec;
-use stellar_xdr::curr::{ScVal, SorobanTransactionMetaExt, TransactionMeta, TransactionResult};
+use stellar_xdr::curr::{ScVal, SorobanTransactionMetaExt, TransactionMeta, TransactionResult, TransactionEnvelope, FeeBumpTransactionInnerTx};
 
 /// Decode `resultMetaXdr` as `TransactionMeta` and, if it is V3, inject the
 /// Soroban contract events, diagnostic events, and return value into the JSON
@@ -135,14 +135,30 @@ pub async fn decode_transaction_with_op_filter(
 ) -> PrismResult<Vec<DiagnosticReport>> {
     let rpc = crate::rpc::SorobanRpcClient::new(network);
     let tx_data = rpc.get_transaction(tx_hash).await?;
-    let base_tx_data = serde_json::to_value(tx_data)
+    let mut base_tx_data = serde_json::to_value(tx_data)
         .map_err(|e| crate::error::PrismError::Internal(e.to_string()))?;
 
-    parse_v3_metadata(&mut tx_data)?;
+    // Parse V3 metadata and inject events/returnValue/fees into the base transaction JSON.
+    parse_v3_metadata(&mut base_tx_data)?;
 
-    if let Some(index) = op_index {
-        filter_transaction_by_operation(&mut tx_data, index)?;
-    }
+    // Decode the envelope XDR to determine the number of operations in the transaction.
+    let num_ops = if let Some(envelope_str) = base_tx_data.get("envelopeXdr").and_then(|v| v.as_str()) {
+        // Use the XDR codec to parse the envelope.
+        let envelope = <stellar_xdr::curr::TransactionEnvelope as crate::xdr::codec::XdrCodec>::from_xdr_base64(envelope_str)
+            .map_err(|e| crate::error::PrismError::Internal(format!("Failed to decode envelope XDR: {}", e)))?;
+        match envelope {
+            stellar_xdr::curr::TransactionEnvelope::Tx(v1) => v1.tx.operations.len(),
+            stellar_xdr::curr::TransactionEnvelope::TxFeeBump(fb) => {
+                // Fee bump transaction contains an inner transaction with its own operations.
+                match &fb.tx.inner_tx {
+                    stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(v1) => v1.tx.operations.len(),
+                }
+            }
+        }
+    } else {
+        // Fallback to a single operation if envelope missing
+        1
+    };
 
     let mut reports = Vec::new();
     let indices = match op_index {


### PR DESCRIPTION
This PR closes #228 
Description
Previously, Prism assumed one operation per transaction, leading to incomplete or misleading output for transactions containing multiple operations. This pull request introduces support for multi-operation transaction decoding.

Key Changes
Core Library (crates/core/src/decode/mod.rs):
Decodes envelopeXdr using the stellar_xdr::curr::TransactionEnvelope struct to determine the exact number of operations (handling both regular and fee-bump transactions).
Iterates over all operation indices independently, producing a Vec<DiagnosticReport> instead of a single report.
Filters transaction logs and events per operation index so each operation's diagnosis is distinct.
CLI Commands (crates/cli/src/commands/decode.rs & inspect.rs):
Updated to handle Vec<DiagnosticReport>.
Clearly labels and renders each operation separately with a header (e.g., === Operation X ===) when a transaction contains multiple operations.
Prints transaction-level fee stats only once (associated with the first report).
Saves the resulting reports as a JSON array when the --save parameter is provided.