### PR TITLE
Attach User-Agent header to RPC client (prism-cli/<version>)

### DIFF
--- a/crates/core/src/rpc/client.rs
+++ b/crates/core/src/rpc/client.rs
@@ -3,7 +3,7 @@
 use crate::error::{PrismError, PrismResult};
 use crate::network::NetworkConfig;
 use crate::rpc::jsonrpc::{JsonRpcRequest, JsonRpcResponse};
-use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE, USER_AGENT};
+use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
 use serde::{Deserialize, Serialize};
 use std::time::{Duration, Instant};
 
@@ -121,10 +121,10 @@ impl SorobanRpcClient {
     pub fn new(config: &NetworkConfig) -> Self {
         let mut headers = HeaderMap::new();
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-        headers.insert(USER_AGENT, HeaderValue::from_static("Prism/0.1.0"));
 
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(config.request_timeout_secs))
+            .user_agent(concat!("prism-cli/", env!("CARGO_PKG_VERSION")))
             .default_headers(headers)
             .build()
             .expect("Failed to build reqwest client");
@@ -138,9 +138,9 @@ impl SorobanRpcClient {
     pub fn with_timeout(mut self, timeout_secs: u64) -> Self {
         let mut headers = HeaderMap::new();
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-        headers.insert(USER_AGENT, HeaderValue::from_static("Prism/0.1.0"));
         self.client = reqwest::Client::builder()
             .timeout(Duration::from_secs(timeout_secs))
+            .user_agent(concat!("prism-cli/", env!("CARGO_PKG_VERSION")))
             .default_headers(headers)
             .build()
             .expect("Failed to build reqwest client");

--- a/crates/core/src/rpc/jsonrpc.rs
+++ b/crates/core/src/rpc/jsonrpc.rs
@@ -92,14 +92,11 @@ impl JsonRpcTransport {
             reqwest::header::CONTENT_TYPE,
             reqwest::header::HeaderValue::from_static("application/json"),
         );
-        headers.insert(
-            reqwest::header::USER_AGENT,
-            reqwest::header::HeaderValue::from_static("Prism/0.1.0"),
-        );
 
         Self {
             client: reqwest::Client::builder()
                 .timeout(std::time::Duration::from_secs(30))
+                .user_agent(concat!("prism-cli/", env!("CARGO_PKG_VERSION")))
                 .default_headers(headers)
                 .build()
                 .expect("failed to build HTTP client"),


### PR DESCRIPTION
Sets a User-Agent: prism-cli/<version> header on the reqwest client builder so outbound RPC requests are identifiable in server logs. Header is configured once at client construction via ClientBuilder::user_agent, applying to all requests made through that client instance. Closes #219.