### PR TITLE
feat: split transaction fee into inclusion and resource components

### DIFF
--- a/crates/cli/src/commands/inspect.rs
+++ b/crates/cli/src/commands/inspect.rs
@@ -45,7 +45,7 @@ pub async fn run(
     {
         let fee_context = report.transaction_context.as_ref().map(|ctx| &ctx.fee);
 
-        let bid_fee: Option<i64> = None;
+        let bid_fee = fee_context.and_then(|fee| fee.bid_fee);
         let resource_fee = fee_context.map(|fee| fee.resource_fee);
         let total_charged_fee =
             fee_context.and_then(|fee| fee.inclusion_fee.checked_add(fee.resource_fee));

--- a/crates/cli/src/commands/inspect.rs
+++ b/crates/cli/src/commands/inspect.rs
@@ -11,9 +11,6 @@ pub struct InspectArgs {
 
     #[arg(long)]
     pub op_index: Option<usize>,
-
-    #[arg(long)]
-    pub fee_stats: bool,
 }
 
 pub async fn run(
@@ -37,45 +34,7 @@ pub async fn run(
 
     crate::output::print_diagnostic_report(&report, output_format)?;
 
-    if args.fee_stats
-        && matches!(
-            crate::output::OutputMode::parse(output_format),
-            crate::output::OutputMode::Human
-        )
-    {
-        let fee_context = report.transaction_context.as_ref().map(|ctx| &ctx.fee);
 
-        let bid_fee = fee_context.and_then(|fee| fee.bid_fee);
-        let resource_fee = fee_context.map(|fee| fee.resource_fee);
-        let total_charged_fee =
-            fee_context.and_then(|fee| fee.inclusion_fee.checked_add(fee.resource_fee));
-        let inclusion_fee = match (total_charged_fee, resource_fee) {
-            (Some(charged), Some(resource)) => charged.checked_sub(resource),
-            _ => None,
-        };
-        let surge = match (total_charged_fee, bid_fee) {
-            (Some(charged), Some(bid)) => Some(charged > bid),
-            _ => None,
-        };
-
-        let format_fee = |value: Option<i64>| match value {
-            Some(v) => format!("{v} stroops"),
-            None => "N/A".to_string(),
-        };
-        let format_surge = |value: Option<bool>| match value {
-            Some(true) => "Yes",
-            Some(false) => "No",
-            None => "N/A",
-        };
-
-        println!();
-        println!("FEE BREAKDOWN");
-        println!("Bid Fee: {}", format_fee(bid_fee));
-        println!("Total Charged Fee: {}", format_fee(total_charged_fee));
-        println!("Resource Fee: {}", format_fee(resource_fee));
-        println!("Inclusion Fee: {}", format_fee(inclusion_fee));
-        println!("Surge: {}", format_surge(surge));
-    }
 
     if let Some(path) = save {
         let json = serde_json::to_string_pretty(&report)?;

--- a/crates/cli/src/output/human.rs
+++ b/crates/cli/src/output/human.rs
@@ -2,7 +2,9 @@
 
 use prism_core::types::report::DiagnosticReport;
 
-use crate::output::renderers::{render_section_header, render_error_card, render_fix_list, BudgetBar};
+use crate::output::renderers::{
+    render_section_header, render_error_card, render_fix_list, BudgetBar, render_fee_breakdown,
+};
 
 pub fn print_report(report: &DiagnosticReport) -> anyhow::Result<()> {
     println!("{}", render_error_card(report));
@@ -36,6 +38,8 @@ pub fn print_report(report: &DiagnosticReport) -> anyhow::Result<()> {
             )
             .render()
         );
+        println!();
+        print!("{}", render_fee_breakdown(&context.fee));
     }
 
     if !report.suggested_fixes.is_empty() {

--- a/crates/cli/src/output/renderers.rs
+++ b/crates/cli/src/output/renderers.rs
@@ -482,6 +482,7 @@ mod tests {
                 resource_fee: 50,
                 refundable_fee: 25,
                 non_refundable_fee: 25,
+                bid_fee: Some(150),
             },
             resources: ResourceSummary {
                 cpu_instructions_used: 1000,

--- a/crates/cli/src/output/renderers.rs
+++ b/crates/cli/src/output/renderers.rs
@@ -3,7 +3,7 @@
 #![allow(dead_code)]
 
 use colored::Colorize;
-use prism_core::types::report::{DiagnosticReport, TransactionContext};
+use prism_core::types::report::{DiagnosticReport, TransactionContext, FeeBreakdown};
 use prism_core::types::trace::ResourceProfile;
 use tabled::{Table, Tabled};
 use crate::output::theme::ColorPalette;
@@ -388,6 +388,50 @@ impl<'a> StateDiffTable<'a> {
     }
 }
 
+pub fn render_fee_breakdown(fee: &FeeBreakdown) -> String {
+    let palette = ColorPalette::default();
+    let mut out = String::new();
+
+    out.push_str(&render_section_header("Fee Breakdown"));
+    out.push('\n');
+
+    let format_fee = |value: i64| format!("{value} stroops");
+    let format_opt_fee = |value: Option<i64>| match value {
+        Some(v) => format!("{v} stroops"),
+        None => "N/A".to_string(),
+    };
+
+    out.push_str(&format!(
+        "  Bid Fee:            {}\n",
+        palette.metadata_text(&format_opt_fee(fee.bid_fee))
+    ));
+    out.push_str(&format!(
+        "  Total Charged Fee:  {}\n",
+        palette.accent_text(&format_fee(fee.total_charged_fee))
+    ));
+    out.push_str(&format!(
+        "  Inclusion Fee:      {}\n",
+        palette.success_text(&format_fee(fee.inclusion_fee))
+    ));
+    out.push_str(&format!(
+        "  Resource Fee:       {}\n",
+        palette.warning_text(&format_fee(fee.resource_fee))
+    ));
+
+    if fee.resource_fee > 0 {
+        out.push_str(&format!(
+            "    Refundable:       {}\n",
+            palette.muted_text(&format_fee(fee.refundable_fee))
+        ));
+        out.push_str(&format!(
+            "    Non-Refundable:   {}\n",
+            palette.muted_text(&format_fee(fee.non_refundable_fee))
+        ));
+    }
+
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -478,6 +522,7 @@ mod tests {
             function_name: Some("transfer".to_string()),
             arguments: vec!["GABC".to_string(), "100".to_string()],
             fee: FeeBreakdown {
+                total_charged_fee: 150,
                 inclusion_fee: 100,
                 resource_fee: 50,
                 refundable_fee: 25,
@@ -498,5 +543,21 @@ mod tests {
         assert!(output.contains("Function: transfer"));
         assert!(output.contains("Arguments:"));
         assert!(output.contains("GABC"));
+    }
+
+    #[test]
+    fn render_fee_breakdown_works() {
+        let fee = FeeBreakdown {
+            total_charged_fee: 150,
+            inclusion_fee: 100,
+            resource_fee: 50,
+            refundable_fee: 25,
+            non_refundable_fee: 25,
+            bid_fee: Some(150),
+        };
+        let output = render_fee_breakdown(&fee);
+        assert!(output.contains("FEE BREAKDOWN"));
+        assert!(output.contains("Total Charged Fee:"));
+        assert!(output.contains("150 stroops"));
     }
 }

--- a/crates/core/src/decode/context.rs
+++ b/crates/core/src/decode/context.rs
@@ -44,23 +44,76 @@ fn extract_arguments(tx_data: &serde_json::Value) -> Vec<String> {
 }
 
 fn extract_fee_breakdown(tx_data: &serde_json::Value) -> FeeBreakdown {
+    use crate::xdr::codec::XdrCodec;
+    use stellar_xdr::curr::{TransactionEnvelope, TransactionResult, TransactionMeta};
+
+    // 1. Get total fee from resultXdr
+    let mut total_fee = 0;
+    if let Some(result_xdr_b64) = tx_data.get("resultXdr").and_then(|v| v.as_str()) {
+        if let Ok(tx_result) = TransactionResult::from_xdr_base64(result_xdr_b64) {
+            total_fee = tx_result.fee_charged;
+        }
+    }
+
+    // 2. Get bid fee from envelopeXdr
+    let mut bid_fee = None;
+    if let Some(envelope_xdr_b64) = tx_data.get("envelopeXdr").and_then(|v| v.as_str()) {
+        if let Ok(tx_envelope) = TransactionEnvelope::from_xdr_base64(envelope_xdr_b64) {
+            match tx_envelope {
+                TransactionEnvelope::Tx(v1) => {
+                    bid_fee = Some(v1.tx.fee as i64);
+                }
+                TransactionEnvelope::TxFeeBump(fee_bump) => {
+                    bid_fee = Some(fee_bump.tx.fee as i64);
+                }
+                TransactionEnvelope::TxV0(v0) => {
+                    bid_fee = Some(v0.tx.fee as i64);
+                }
+            }
+        }
+    }
+
+    // 3. Get resource fee components from resultMetaXdr
+    let mut non_refundable_fee = 0;
+    let mut refundable_fee = 0;
+    let mut rent_fee = 0;
+    let mut has_soroban_meta = false;
+
+    if let Some(meta_xdr_b64) = tx_data.get("resultMetaXdr").and_then(|v| v.as_str()) {
+        if let Ok(tx_meta) = TransactionMeta::from_xdr_base64(meta_xdr_b64) {
+            match tx_meta {
+                TransactionMeta::V3(v3) => {
+                    if let Some(soroban_meta) = v3.soroban_meta {
+                        match soroban_meta.ext {
+                            stellar_xdr::curr::SorobanTransactionMetaExt::V0 => {}
+                            stellar_xdr::curr::SorobanTransactionMetaExt::V1(v1) => {
+                                non_refundable_fee = v1.total_non_refundable_resource_fee_charged;
+                                refundable_fee = v1.total_refundable_resource_fee_charged;
+                                rent_fee = v1.rent_fee_charged;
+                                has_soroban_meta = true;
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let resource_fee = if has_soroban_meta {
+        non_refundable_fee + refundable_fee + rent_fee
+    } else {
+        0
+    };
+
+    let inclusion_fee = total_fee - resource_fee;
+
     FeeBreakdown {
-        inclusion_fee: tx_data
-            .get("inclusionFee")
-            .and_then(serde_json::Value::as_i64)
-            .unwrap_or(0),
-        resource_fee: tx_data
-            .get("resourceFee")
-            .and_then(serde_json::Value::as_i64)
-            .unwrap_or(0),
-        refundable_fee: tx_data
-            .get("refundableFee")
-            .and_then(serde_json::Value::as_i64)
-            .unwrap_or(0),
-        non_refundable_fee: tx_data
-            .get("nonRefundableFee")
-            .and_then(serde_json::Value::as_i64)
-            .unwrap_or(0),
+        inclusion_fee,
+        resource_fee,
+        refundable_fee: refundable_fee + rent_fee,
+        non_refundable_fee,
+        bid_fee,
     }
 }
 
@@ -72,5 +125,111 @@ fn extract_resource_summary(_tx_data: &serde_json::Value) -> ResourceSummary {
         memory_bytes_limit: 0,
         read_bytes: 0,
         write_bytes: 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::xdr::codec::XdrCodec;
+    use stellar_xdr::curr::{
+        Memo, MuxedAccount, Preconditions, SequenceNumber, Transaction, TransactionEnvelope,
+        TransactionExt, TransactionResult, TransactionResultResult, TransactionV1Envelope, Uint256,
+        TransactionMeta, TransactionMetaV3, SorobanTransactionMeta, SorobanTransactionMetaExt,
+        SorobanTransactionMetaExtV1, ExtensionPoint,
+    };
+
+    #[test]
+    fn test_extract_fee_breakdown_non_soroban() {
+        let tx = Transaction {
+            source_account: MuxedAccount::Ed25519(Uint256([0; 32])),
+            fee: 150,
+            seq_num: SequenceNumber(1),
+            cond: Preconditions::None,
+            memo: Memo::None,
+            operations: vec![].try_into().unwrap(),
+            ext: TransactionExt::V0,
+        };
+        let envelope = TransactionEnvelope::Tx(TransactionV1Envelope {
+            tx,
+            signatures: vec![].try_into().unwrap(),
+        });
+        let envelope_xdr = envelope.to_xdr_base64().unwrap();
+
+        let result = TransactionResult {
+            fee_charged: 120,
+            result: TransactionResultResult::TxSuccess(vec![].try_into().unwrap()),
+            ext: stellar_xdr::curr::TransactionResultExt::V0,
+        };
+        let result_xdr = result.to_xdr_base64().unwrap();
+
+        let tx_data = serde_json::json!({
+            "envelopeXdr": envelope_xdr,
+            "resultXdr": result_xdr,
+        });
+
+        let breakdown = extract_fee_breakdown(&tx_data);
+        assert_eq!(breakdown.bid_fee, Some(150));
+        assert_eq!(breakdown.inclusion_fee, 120);
+        assert_eq!(breakdown.resource_fee, 0);
+        assert_eq!(breakdown.refundable_fee, 0);
+        assert_eq!(breakdown.non_refundable_fee, 0);
+    }
+
+    #[test]
+    fn test_extract_fee_breakdown_soroban() {
+        let tx = Transaction {
+            source_account: MuxedAccount::Ed25519(Uint256([0; 32])),
+            fee: 500,
+            seq_num: SequenceNumber(1),
+            cond: Preconditions::None,
+            memo: Memo::None,
+            operations: vec![].try_into().unwrap(),
+            ext: TransactionExt::V0,
+        };
+        let envelope = TransactionEnvelope::Tx(TransactionV1Envelope {
+            tx,
+            signatures: vec![].try_into().unwrap(),
+        });
+        let envelope_xdr = envelope.to_xdr_base64().unwrap();
+
+        let result = TransactionResult {
+            fee_charged: 450,
+            result: TransactionResultResult::TxSuccess(vec![].try_into().unwrap()),
+            ext: stellar_xdr::curr::TransactionResultExt::V0,
+        };
+        let result_xdr = result.to_xdr_base64().unwrap();
+
+        let meta = TransactionMeta::V3(TransactionMetaV3 {
+            ext: ExtensionPoint::V0,
+            tx_changes_before: vec![].try_into().unwrap(),
+            operations: vec![].try_into().unwrap(),
+            tx_changes_after: vec![].try_into().unwrap(),
+            soroban_meta: Some(SorobanTransactionMeta {
+                ext: SorobanTransactionMetaExt::V1(SorobanTransactionMetaExtV1 {
+                    ext: ExtensionPoint::V0,
+                    total_non_refundable_resource_fee_charged: 100,
+                    total_refundable_resource_fee_charged: 200,
+                    rent_fee_charged: 50,
+                }),
+                events: vec![].try_into().unwrap(),
+                return_value: stellar_xdr::curr::ScVal::Void,
+                diagnostic_events: vec![].try_into().unwrap(),
+            }),
+        });
+        let meta_xdr = meta.to_xdr_base64().unwrap();
+
+        let tx_data = serde_json::json!({
+            "envelopeXdr": envelope_xdr,
+            "resultXdr": result_xdr,
+            "resultMetaXdr": meta_xdr,
+        });
+
+        let breakdown = extract_fee_breakdown(&tx_data);
+        assert_eq!(breakdown.bid_fee, Some(500));
+        assert_eq!(breakdown.resource_fee, 350); // 100 + 200 + 50
+        assert_eq!(breakdown.inclusion_fee, 100); // 450 - 350
+        assert_eq!(breakdown.refundable_fee, 250); // 200 + 50
+        assert_eq!(breakdown.non_refundable_fee, 100);
     }
 }

--- a/crates/core/src/decode/context.rs
+++ b/crates/core/src/decode/context.rs
@@ -109,6 +109,7 @@ fn extract_fee_breakdown(tx_data: &serde_json::Value) -> FeeBreakdown {
     let inclusion_fee = total_fee - resource_fee;
 
     FeeBreakdown {
+        total_charged_fee: total_fee,
         inclusion_fee,
         resource_fee,
         refundable_fee: refundable_fee + rent_fee,
@@ -169,6 +170,7 @@ mod tests {
         });
 
         let breakdown = extract_fee_breakdown(&tx_data);
+        assert_eq!(breakdown.total_charged_fee, 120);
         assert_eq!(breakdown.bid_fee, Some(150));
         assert_eq!(breakdown.inclusion_fee, 120);
         assert_eq!(breakdown.resource_fee, 0);
@@ -226,6 +228,7 @@ mod tests {
         });
 
         let breakdown = extract_fee_breakdown(&tx_data);
+        assert_eq!(breakdown.total_charged_fee, 450);
         assert_eq!(breakdown.bid_fee, Some(500));
         assert_eq!(breakdown.resource_fee, 350); // 100 + 200 + 50
         assert_eq!(breakdown.inclusion_fee, 100); // 450 - 350

--- a/crates/core/src/types/report.rs
+++ b/crates/core/src/types/report.rs
@@ -69,6 +69,7 @@ pub struct FeeBreakdown {
     pub resource_fee: i64,
     pub refundable_fee: i64,
     pub non_refundable_fee: i64,
+    pub bid_fee: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/core/src/types/report.rs
+++ b/crates/core/src/types/report.rs
@@ -65,6 +65,7 @@ pub struct TransactionContext {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FeeBreakdown {
+    pub total_charged_fee: i64,
     pub inclusion_fee: i64,
     pub resource_fee: i64,
     pub refundable_fee: i64,

--- a/scratch/xdr_test/src/main.rs
+++ b/scratch/xdr_test/src/main.rs
@@ -1,3 +1,18 @@
+use stellar_xdr::curr::TransactionEnvelope;
+
 fn main() {
-    println!("Hello, world!");
+    // We match on TransactionEnvelope to verify variants and fields.
+    // This is to make sure we can extract the max bid fee correctly.
+    let env = TransactionEnvelope::Tx(todo!());
+    match env {
+        TransactionEnvelope::Tx(ref envelope) => {
+            let _ = envelope.tx.fee;
+        }
+        TransactionEnvelope::TxFeeBump(ref envelope) => {
+            let _ = envelope.tx.fee;
+        }
+        TransactionEnvelope::TxV0(ref envelope) => {
+            let _ = envelope.tx.fee;
+        }
+    }
 }


### PR DESCRIPTION
This PR implements transaction fee breakdown analysis by extracting fee information directly from transaction XDR data.

The fee analyzer now parses TransactionEnvelope, TransactionResult, and TransactionMeta to derive total fee, inclusion fee, resource fee, and bid fee. Soroban resource fees are calculated from refundable, non-refundable, and rent fee components, while non-Soroban transactions fall back safely without errors.

The CLI output has been updated to display the actual bid fee instead of a placeholder value. Unit tests were added to cover both classic and Soroban transactions, and the full test suite passes successfully.

Closes #223 