### PR TITLE
feat: handle edge cases in scval decoder and add tests

### DIFF
--- a/crates/core/src/decode/diagnostic.rs
+++ b/crates/core/src/decode/diagnostic.rs
@@ -30,6 +30,30 @@ fn scval_to_string(val: &ScVal) -> Option<String> {
         ScVal::I32(i) => Some(i.to_string()),
         ScVal::U64(u) => Some(u.to_string()),
         ScVal::I64(i) => Some(i.to_string()),
+        ScVal::Void => Some("Void".to_string()),
+        ScVal::Bool(b) => Some(b.to_string()),
+        ScVal::U128(u) => {
+            let num = ((u.hi as u128) << 64) | (u.lo as u128);
+            Some(num.to_string())
+        }
+        ScVal::I128(i) => {
+            let num = ((i.hi as i128) << 64) | (i.lo as u128 as i128);
+            Some(num.to_string())
+        }
+        ScVal::Vec(Some(v)) => {
+            let items: Vec<String> = v.iter().map(|item| {
+                scval_to_string(item).unwrap_or_else(|| "?".to_string())
+            }).collect();
+            Some(format!("[{}]", items.join(", ")))
+        }
+        ScVal::Map(Some(m)) => {
+            let items: Vec<String> = m.iter().map(|entry| {
+                let k = scval_to_string(&entry.key).unwrap_or_else(|| "?".to_string());
+                let v = scval_to_string(&entry.val).unwrap_or_else(|| "?".to_string());
+                format!("{}: {}", k, v)
+            }).collect();
+            Some(format!("{{{}}}", items.join(", ")))
+        }
         _ => None,
     }
 }
@@ -107,5 +131,40 @@ fn analyze_diagnostic_event(report: &mut DiagnosticReport, event: &DiagnosticEve
                 report.detailed_explanation.push_str(&format!("\n- [{}]", topics_str));
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stellar_xdr::curr::{ScVal, ScVec, ScMap, ScMapEntry, Int128Parts};
+
+    #[test]
+    fn test_scval_to_string_empty_args() {
+        let empty_vec = ScVal::Vec(Some(ScVec(vec![].try_into().unwrap())));
+        assert_eq!(scval_to_string(&empty_vec), Some("[]".to_string()));
+        let void_val = ScVal::Void;
+        assert_eq!(scval_to_string(&void_val), Some("Void".to_string()));
+    }
+
+    #[test]
+    fn test_scval_to_string_large_integers() {
+        let u128_val = ScVal::U128(Int128Parts { hi: 1, lo: 0 });
+        assert_eq!(scval_to_string(&u128_val), Some("18446744073709551616".to_string()));
+
+        let i128_val = ScVal::I128(Int128Parts { hi: -1i64, lo: 0 });
+        assert_eq!(scval_to_string(&i128_val), Some("-18446744073709551616".to_string()));
+    }
+
+    #[test]
+    fn test_scval_to_string_nested_map() {
+        let map_entry = ScMapEntry {
+            key: ScVal::Symbol("key".try_into().unwrap()),
+            val: ScVal::U32(42),
+        };
+        let scmap = ScMap(vec![map_entry].try_into().unwrap());
+        let nested_map = ScVal::Map(Some(scmap));
+        let vec_val = ScVal::Vec(Some(ScVec(vec![nested_map].try_into().unwrap())));
+        assert_eq!(scval_to_string(&vec_val), Some("[{key: 42}]".to_string()));
     }
 }

--- a/crates/core/src/decode/diagnostic.rs
+++ b/crates/core/src/decode/diagnostic.rs
@@ -140,6 +140,18 @@ mod tests {
     use stellar_xdr::curr::{ScVal, ScVec, ScMap, ScMapEntry, Int128Parts};
 
     #[test]
+    fn test_scval_to_string_supported_variants() {
+        assert_eq!(scval_to_string(&ScVal::String("hello".try_into().unwrap())), Some("hello".to_string()));
+        assert_eq!(scval_to_string(&ScVal::Bool(true)), Some("true".to_string()));
+        assert_eq!(scval_to_string(&ScVal::Bool(false)), Some("false".to_string()));
+        assert_eq!(scval_to_string(&ScVal::I32(-2147483648)), Some("-2147483648".to_string()));
+        assert_eq!(scval_to_string(&ScVal::I32(2147483647)), Some("2147483647".to_string()));
+        assert_eq!(scval_to_string(&ScVal::U64(18446744073709551615)), Some("18446744073709551615".to_string()));
+        assert_eq!(scval_to_string(&ScVal::I64(-9223372036854775808)), Some("-9223372036854775808".to_string()));
+        assert_eq!(scval_to_string(&ScVal::I64(9223372036854775807)), Some("9223372036854775807".to_string()));
+    }
+
+    #[test]
     fn test_scval_to_string_empty_args() {
         let empty_vec = ScVal::Vec(Some(ScVec(vec![].try_into().unwrap())));
         assert_eq!(scval_to_string(&empty_vec), Some("[]".to_string()));
@@ -149,11 +161,29 @@ mod tests {
 
     #[test]
     fn test_scval_to_string_large_integers() {
+        // U128 standard
         let u128_val = ScVal::U128(Int128Parts { hi: 1, lo: 0 });
         assert_eq!(scval_to_string(&u128_val), Some("18446744073709551616".to_string()));
 
+        // I128 standard
         let i128_val = ScVal::I128(Int128Parts { hi: -1i64, lo: 0 });
         assert_eq!(scval_to_string(&i128_val), Some("-18446744073709551616".to_string()));
+
+        // U128 Max: hi is -1 (all 1s), lo is u64::MAX
+        let u128_max = ScVal::U128(Int128Parts { hi: -1i64, lo: u64::MAX });
+        assert_eq!(scval_to_string(&u128_max), Some("340282366920938463463374607431768211455".to_string()));
+
+        // U128 Min: 0
+        let u128_min = ScVal::U128(Int128Parts { hi: 0, lo: 0 });
+        assert_eq!(scval_to_string(&u128_min), Some("0".to_string()));
+
+        // I128 Max: hi is i64::MAX, lo is u64::MAX
+        let i128_max = ScVal::I128(Int128Parts { hi: i64::MAX, lo: u64::MAX });
+        assert_eq!(scval_to_string(&i128_max), Some("170141183460469231731687303715884105727".to_string()));
+
+        // I128 Min: hi is i64::MIN, lo is 0
+        let i128_min = ScVal::I128(Int128Parts { hi: i64::MIN, lo: 0 });
+        assert_eq!(scval_to_string(&i128_min), Some("-170141183460469231731687303715884105728".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Description
The argument decoder (`scval_to_string`) was silently ignoring complex `ScVal` variants, producing missing or incorrect outputs. This PR updates the decoder to accurately translate the remaining variants into readable string representations. 

## Changes Made
- Added handling for `ScVal::Void` and empty vectors to represent empty arguments correctly.
- Added handling for `ScVal::U128` and `ScVal::I128` to correctly decode max-size integers.
- Added recursive decoding support for `ScVal::Vec` and `ScVal::Map`, allowing for nested mappings inside vectors.
- Introduced a full unit test suite within the `decode::diagnostic` module to ensure all edge cases are strictly covered and verified.

## Testing
- Unit tests added for:
  - Empty args (`ScVal::Void`, empty `ScVec`)
  - Large integers (Max/Negative `128-bit` parsing)
  - Nested types (an `ScMap` inside an `ScVec`)
  
  Closes #244 