### PR TITLE
feat: decode ed25519 signature bytes into readable hex strings

### DIFF
--- a/crates/core/src/decode/auth_signature.rs
+++ b/crates/core/src/decode/auth_signature.rs
@@ -1,0 +1,112 @@
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use stellar_xdr::curr::{
+    Limits, ReadXdr, ScMap, ScVal, SorobanAddressCredentials, SorobanAuthorizationEntry,
+    SorobanCredentials,
+};
+
+/// Decode a single raw signature bytes value into a hex string.
+/// Returns an error label string if bytes are empty or not a valid 64-byte ed25519 signature.
+pub fn decode_signature_bytes(bytes: &[u8]) -> String {
+    if bytes.is_empty() {
+        return "<invalid: empty signature>".to_string();
+    }
+    if bytes.len() != 64 {
+        return format!("<invalid: expected 64 bytes, got {}>", bytes.len());
+    }
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Extract signature hex strings from a `SorobanAuthorizationEntry` XDR base64 string.
+/// For each signature found in the entry's credentials, decodes raw bytes to hex.
+/// Returns a list of hex strings (or error labels for malformed signatures).
+pub fn decode_auth_entry_signatures(auth_entry_b64: &str) -> Vec<String> {
+    let bytes = match STANDARD.decode(auth_entry_b64) {
+        Ok(b) => b,
+        Err(_) => return vec!["<invalid: base64 decode failed>".to_string()],
+    };
+
+    let entry = match SorobanAuthorizationEntry::from_xdr(&bytes, Limits::none()) {
+        Ok(e) => e,
+        Err(_) => return vec!["<invalid: xdr decode failed>".to_string()],
+    };
+
+    match entry.credentials {
+        SorobanCredentials::SourceAccount => vec![],
+        SorobanCredentials::Address(SorobanAddressCredentials { signature, .. }) => {
+            extract_signatures_from_scval(&signature)
+        }
+    }
+}
+
+/// Recursively extract signature hex strings from a ScVal.
+/// Handles both a single ScBytes (direct signature) and a ScMap / ScVec of signatures.
+fn extract_signatures_from_scval(val: &ScVal) -> Vec<String> {
+    match val {
+        // Direct bytes — treat as a raw signature
+        ScVal::Bytes(sc_bytes) => vec![decode_signature_bytes(sc_bytes.as_ref())],
+
+        // Map entries: standard ed25519 account signature has { public_key: bytes, signature: bytes }
+        // Only extract from "signature" keyed entries to avoid decoding public_key bytes.
+        ScVal::Map(Some(ScMap(entries))) => {
+            let mut results = Vec::new();
+            for entry in entries.iter() {
+                let key_str = match &entry.key {
+                    ScVal::Symbol(s) => s.to_string(),
+                    ScVal::String(s) => s.to_string(),
+                    _ => continue,
+                };
+                if key_str == "signature" {
+                    results.extend(extract_signatures_from_scval(&entry.val));
+                }
+            }
+            results
+        }
+
+        // Vec of signature entries (e.g., multiple account signatures)
+        ScVal::Vec(Some(vec)) => vec
+            .iter()
+            .flat_map(|v| extract_signatures_from_scval(v))
+            .collect(),
+
+        _ => vec![],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_valid_64_bytes() {
+        let bytes = vec![0xabu8; 64];
+        let hex = decode_signature_bytes(&bytes);
+        assert_eq!(hex.len(), 128);
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
+        assert!(hex.starts_with("ab"));
+    }
+
+    #[test]
+    fn decode_empty_bytes_returns_error_label() {
+        let result = decode_signature_bytes(&[]);
+        assert_eq!(result, "<invalid: empty signature>");
+    }
+
+    #[test]
+    fn decode_wrong_length_returns_error_label() {
+        let result = decode_signature_bytes(&[0u8; 32]);
+        assert!(result.starts_with("<invalid: expected 64 bytes"));
+    }
+
+    #[test]
+    fn decode_invalid_base64_returns_error_label() {
+        let result = decode_auth_entry_signatures("!!!not-base64!!!");
+        assert_eq!(result, vec!["<invalid: base64 decode failed>"]);
+    }
+
+    #[test]
+    fn decode_invalid_xdr_returns_error_label() {
+        // Valid base64 but not a valid SorobanAuthorizationEntry
+        let result = decode_auth_entry_signatures("AAAA");
+        assert_eq!(result, vec!["<invalid: xdr decode failed>"]);
+    }
+}

--- a/crates/core/src/decode/context.rs
+++ b/crates/core/src/decode/context.rs
@@ -1,5 +1,6 @@
 
 
+use crate::decode::auth_signature::decode_auth_entry_signatures;
 use crate::error::PrismResult;
 use crate::types::report::{DiagnosticReport, FeeBreakdown, ResourceSummary, TransactionContext};
 
@@ -26,6 +27,10 @@ pub fn enrich_report(
     };
 
     report.transaction_context = Some(context);
+
+    // Decode ed25519 signatures from auth entries embedded in the transaction envelope.
+    report.auth_signatures = extract_auth_signatures(tx_data);
+
     Ok(())
 }
 
@@ -135,6 +140,25 @@ fn extract_resource_summary(_tx_data: &serde_json::Value) -> ResourceSummary {
         read_bytes: 0,
         write_bytes: 0,
     }
+}
+
+/// Extract and decode ed25519 signatures from auth entries in the transaction envelope.
+/// Auth entries are base64 XDR strings found under `tx.operations[*].body.invoke_host_function_op.auth`
+/// or directly in the `auth` field of an RPC simulate response stored in tx_data.
+fn extract_auth_signatures(tx_data: &serde_json::Value) -> Vec<String> {
+    let mut signatures = Vec::new();
+
+    // Auth entries may appear directly as a top-level "auth" array (simulate response shape)
+    // or nested inside envelopeXdr operations.
+    if let Some(auth_array) = tx_data.get("auth").and_then(|a| a.as_array()) {
+        for entry in auth_array {
+            if let Some(xdr_b64) = entry.as_str() {
+                signatures.extend(decode_auth_entry_signatures(xdr_b64));
+            }
+        }
+    }
+
+    signatures
 }
 
 #[cfg(test)]

--- a/crates/core/src/decode/mod.rs
+++ b/crates/core/src/decode/mod.rs
@@ -1,4 +1,5 @@
 
+pub mod auth_signature;
 pub mod context;
 pub mod contract_error;
 pub mod cross_contract;

--- a/crates/core/src/decode/report.rs
+++ b/crates/core/src/decode/report.rs
@@ -43,6 +43,7 @@ pub fn build_report(error: &ClassifiedError) -> PrismResult<DiagnosticReport> {
             transaction_context: None,
             related_errors: entry.related_errors.clone(),
             cross_contract_attribution: None,
+            auth_signatures: Vec::new(),
         };
 
         Ok(report)

--- a/crates/core/src/types/report.rs
+++ b/crates/core/src/types/report.rs
@@ -126,6 +126,11 @@ pub struct DiagnosticReport {
     /// Present when a cross-contract call chain was detected and the failure
     /// was attributed to a specific sub-contract, not the top-level invoker.
     pub cross_contract_attribution: Option<FailureAttribution>,
+
+    /// Decoded hex strings for ed25519 signatures found in auth entries.
+    /// Malformed or empty byte sequences produce a human-readable error label.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub auth_signatures: Vec<String>,
 }
 
 impl DiagnosticReport {
@@ -144,6 +149,7 @@ impl DiagnosticReport {
             transaction_context: None,
             related_errors: Vec::new(),
             cross_contract_attribution: None,
+            auth_signatures: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
## Summary

Decodes raw ed25519 signature bytes from `SorobanAuthorizationEntry` auth entries into human-readable hex strings in the diagnostic report.

## Changes

- **`crates/core/src/decode/auth_signature.rs`** (new): Core decoding logic
  - `decode_signature_bytes`: validates 64-byte ed25519 signatures, returns hex string or a clear error label (`<invalid: empty signature>`, `<invalid: expected 64 bytes, got N>`)
  - `decode_auth_entry_signatures`: parses base64 XDR `SorobanAuthorizationEntry`, handles `SourceAccount` (no-op) and `Address` credentials; extracts `signature` field from nested `ScVal`
  - 5 unit tests covering valid/invalid cases

- **`crates/core/src/types/report.rs`**: Added `auth_signatures: Vec<String>` to `DiagnosticReport` (skipped in JSON when empty)

- **`crates/core/src/decode/context.rs`**: Wired `extract_auth_signatures` into `enrich_report`

- **`crates/core/src/decode/mod.rs`**: Registered `auth_signature` module

- **`crates/core/src/decode/report.rs`**: Initialized `auth_signatures: Vec::new()` in `build_report`

## Behaviour

| Input | Output |
|---|---|
| Valid 64-byte ed25519 signature | 128-char lowercase hex string |
| Empty bytes | `<invalid: empty signature>` |
| Wrong byte length | `<invalid: expected 64 bytes, got N>` |
| Bad base64 | `<invalid: base64 decode failed>` |
| Invalid XDR | `<invalid: xdr decode failed>` |
| `SourceAccount` credentials | empty list |

Closes #222