### PR TITLE
feat: decode address-with-nonce from Soroban auth entries

### DIFF
--- a/crates/core/src/decode/auth.rs
+++ b/crates/core/src/decode/auth.rs
@@ -147,7 +147,7 @@ fn parse_function(function: &SorobanAuthorizedFunction, depth: usize) -> AuthInv
 }
 
 /// Render an `ScAddress` as a strkey (`G...` for accounts, `C...` for contracts).
-fn scaddress_to_strkey(address: &ScAddress) -> String {
+pub(crate) fn scaddress_to_strkey(address: &ScAddress) -> String {
     match address {
         ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(bytes)))) => {
             stellar_strkey::ed25519::PublicKey(*bytes).to_string()

--- a/crates/core/src/decode/auth_address_nonce.rs
+++ b/crates/core/src/decode/auth_address_nonce.rs
@@ -1,0 +1,164 @@
+//! Decode the address-with-nonce credential from a Soroban authorization entry.
+//!
+//! Soroban auth entries carry a nonce that is bound to an authorizing address to
+//! prevent signature replay. In the raw XDR this pair lives inside
+//! `SorobanAddressCredentials` (historically named `SorobanAddressWithNonce`),
+//! nested under the entry's credentials and hard to read at a glance. This module
+//! pulls that pair out and formats it so a reader can clearly see *who* authorized
+//! the entry and the *specific nonce* that protects it.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use stellar_xdr::curr::{SorobanAddressCredentials, SorobanAuthorizationEntry, SorobanCredentials};
+
+use crate::decode::auth::scaddress_to_strkey;
+use crate::error::PrismResult;
+use crate::xdr::codec::XdrCodec;
+
+/// An authorizing address paired with its replay-protection nonce, extracted from
+/// a `SorobanAddressCredentials` (a.k.a. `SorobanAddressWithNonce`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AddressWithNonce {
+    /// The authorizing address as a strkey (`G...` account or `C...` contract).
+    pub address: String,
+    /// The replay-protection nonce bound to this address.
+    pub nonce: i64,
+}
+
+impl AddressWithNonce {
+    /// Decode the address-with-nonce from a base64 `SorobanAuthorizationEntry`.
+    ///
+    /// Returns `Ok(None)` for source-account credentials, which carry no address
+    /// or nonce of their own — they reuse the transaction's source account.
+    pub fn from_auth_entry_base64(b64: &str) -> PrismResult<Option<Self>> {
+        let entry = SorobanAuthorizationEntry::from_xdr_base64(b64)?;
+        Ok(Self::from_entry(&entry))
+    }
+
+    /// Extract the address-with-nonce from a decoded auth entry, when it uses
+    /// address-based credentials.
+    pub fn from_entry(entry: &SorobanAuthorizationEntry) -> Option<Self> {
+        match &entry.credentials {
+            SorobanCredentials::SourceAccount => None,
+            SorobanCredentials::Address(creds) => Some(Self::from_credentials(creds)),
+        }
+    }
+
+    fn from_credentials(creds: &SorobanAddressCredentials) -> Self {
+        Self {
+            address: scaddress_to_strkey(&creds.address),
+            nonce: creds.nonce,
+        }
+    }
+}
+
+impl fmt::Display for AddressWithNonce {
+    /// Render the address and its nonce on separate, clearly labeled lines.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Address: {}", self.address)?;
+        write!(f, "Nonce:   {}", self.nonce)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stellar_xdr::curr::{
+        AccountId, Hash, InvokeContractArgs, PublicKey, ScAddress, ScSymbol, ScVal,
+        SorobanAuthorizedFunction, SorobanAuthorizedInvocation, Uint256,
+    };
+
+    fn account_address(seed: u8) -> ScAddress {
+        ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([seed; 32]))))
+    }
+
+    fn contract_address(seed: u8) -> ScAddress {
+        ScAddress::Contract(Hash([seed; 32]))
+    }
+
+    fn root_invocation(addr: ScAddress) -> SorobanAuthorizedInvocation {
+        SorobanAuthorizedInvocation {
+            function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
+                contract_address: addr,
+                function_name: ScSymbol("f".try_into().unwrap()),
+                args: Vec::new().try_into().unwrap(),
+            }),
+            sub_invocations: Vec::new().try_into().unwrap(),
+        }
+    }
+
+    fn address_entry(addr: ScAddress, nonce: i64) -> SorobanAuthorizationEntry {
+        SorobanAuthorizationEntry {
+            credentials: SorobanCredentials::Address(SorobanAddressCredentials {
+                address: addr.clone(),
+                nonce,
+                signature_expiration_ledger: 0,
+                signature: ScVal::Void,
+            }),
+            root_invocation: root_invocation(addr),
+        }
+    }
+
+    #[test]
+    fn extracts_account_address_and_nonce() {
+        let entry = address_entry(account_address(3), 42);
+        let parsed = AddressWithNonce::from_entry(&entry).expect("address credential");
+        assert!(parsed.address.starts_with('G'));
+        assert_eq!(parsed.nonce, 42);
+    }
+
+    #[test]
+    fn extracts_contract_address_and_nonce() {
+        let entry = address_entry(contract_address(9), -7);
+        let parsed = AddressWithNonce::from_entry(&entry).expect("address credential");
+        assert!(parsed.address.starts_with('C'));
+        assert_eq!(parsed.nonce, -7);
+    }
+
+    #[test]
+    fn source_account_has_no_address_with_nonce() {
+        let entry = SorobanAuthorizationEntry {
+            credentials: SorobanCredentials::SourceAccount,
+            root_invocation: root_invocation(contract_address(1)),
+        };
+        assert!(AddressWithNonce::from_entry(&entry).is_none());
+    }
+
+    #[test]
+    fn display_separates_address_and_nonce() {
+        let entry = address_entry(account_address(5), 1234);
+        let parsed = AddressWithNonce::from_entry(&entry).expect("address credential");
+        let rendered = parsed.to_string();
+        assert!(rendered.contains(&format!("Address: {}", parsed.address)));
+        assert!(rendered.contains("Nonce:   1234"));
+        // Address and nonce land on separate lines.
+        assert_eq!(rendered.lines().count(), 2);
+    }
+
+    #[test]
+    fn round_trips_through_base64() {
+        let entry = address_entry(account_address(7), 99);
+        let b64 = XdrCodec::to_xdr_base64(&entry).expect("encode");
+        let parsed = AddressWithNonce::from_auth_entry_base64(&b64)
+            .expect("decode")
+            .expect("address credential");
+        assert!(parsed.address.starts_with('G'));
+        assert_eq!(parsed.nonce, 99);
+    }
+
+    #[test]
+    fn source_account_base64_yields_none() {
+        let entry = SorobanAuthorizationEntry {
+            credentials: SorobanCredentials::SourceAccount,
+            root_invocation: root_invocation(contract_address(2)),
+        };
+        let b64 = XdrCodec::to_xdr_base64(&entry).expect("encode");
+        let parsed = AddressWithNonce::from_auth_entry_base64(&b64).expect("decode");
+        assert!(parsed.is_none());
+    }
+
+    #[test]
+    fn invalid_base64_is_an_error() {
+        assert!(AddressWithNonce::from_auth_entry_base64("!!!not-valid!!!").is_err());
+    }
+}

--- a/crates/core/src/decode/mod.rs
+++ b/crates/core/src/decode/mod.rs
@@ -1,5 +1,6 @@
 
 pub mod auth;
+pub mod auth_address_nonce;
 pub mod auth_signature;
 pub mod context;
 pub mod contract_error;
@@ -13,6 +14,7 @@ pub mod walker;
 pub use auth::{
     AddressCredential, AuthChain, AuthCredential, AuthFunctionKind, AuthInvocation,
 };
+pub use auth_address_nonce::AddressWithNonce;
 pub use walker::{
     walk_diagnostic_events, DiagnosticEventKind, DiagnosticEventWalker,
     StructuredDiagnosticEvent,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -19,8 +19,9 @@ pub use types::config::NetworkConfig;
 pub use error::{PrismError, PrismResult};
 pub use types::report::DiagnosticReport;
 pub use decode::{
-    walk_diagnostic_events, AddressCredential, AuthChain, AuthCredential, AuthFunctionKind,
-    AuthInvocation, DiagnosticEventKind, DiagnosticEventWalker, StructuredDiagnosticEvent,
+    walk_diagnostic_events, AddressCredential, AddressWithNonce, AuthChain, AuthCredential,
+    AuthFunctionKind, AuthInvocation, DiagnosticEventKind, DiagnosticEventWalker,
+    StructuredDiagnosticEvent,
 };
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
Closes #269 

### Summary
Soroban authorization entries carry a nonce bound to an authorizing address to prevent signature replay. In the raw XDR this pair lives inside `SorobanAddressCredentials` (historically named `SorobanAddressWithNonce`), nested under the entry's credentials and hard to read at a glance.

This PR adds a focused decoder that extracts that structure and **separates and formats the authorizing address and its specific nonce** so they can be displayed clearly.

### Changes
- **New module** `crates/core/src/decode/auth_address_nonce.rs`:
  - `AddressWithNonce` struct — cleanly separates `address` (rendered as a `G…`/`C…` strkey) and `nonce`.
  - `from_auth_entry_base64(&str)` — parses a raw base64 `SorobanAuthorizationEntry` and pulls out the address + nonce.
  - `from_entry(&SorobanAuthorizationEntry)` — same, from an already-decoded entry.
  - `Display` impl — renders the address and nonce on separate, clearly labeled lines.
  - Returns `None` for source-account credentials, which carry no address or nonce of their own.
- Reused the existing `scaddress_to_strkey` helper from `auth.rs` (made it `pub(crate)`) to avoid duplicating strkey logic.
- Exported `AddressWithNonce` from `decode/mod.rs` and the crate root (`lib.rs`).

### Behavior
For an address-based auth entry, decoding now yields a clear, separated view:

Address: GCEXAMPLE...XYZ
Nonce:   1234


Source-account entries return `None` (no address/nonce to show).

### Tests
Added 7 unit tests covering:
- Account (`G…`) and contract (`C…`) address extraction
- Negative nonce values
- Source-account → `None`
- `Display` formatting (separate, labeled lines)
- Base64 round-trip
- Invalid base64 → error

All new tests pass.

### Notes
`prism-core` currently does **not** compile on a clean `main` due to a pre-existing, unrelated breakage from the `DecodeContext` merge (`pub mod decode_context;` missing from `decode/mod.rs`, and a call site in `decode/mod.rs` still passing `&NetworkConfig` where `&DecodeContext` is now expected). This PR does not touch that code. New tests were verified by temporarily patching those two lines locally; the committed diff contains only the changes for this task.
