### PR TITLE
feat: map Wasm host-error codes to human-readable descriptions

### DIFF
--- a/crates/core/src/decode/host_error.rs
+++ b/crates/core/src/decode/host_error.rs
@@ -103,9 +103,12 @@ impl HostError {
                0 => "Contract error: the contract's own logic rejected this call — run with --resolve to map the code to its name.".to_string(),
                 _ => format!("Contract error (code {code}): the contract returned a non-zero error code — run with --resolve to identify it."),
             },
-            Self::Wasm { code } => match code {
-               0 => "Invalid WASM module: the contract bytecode failed validation — recompile with a compatible Soroban SDK version.".to_string(),
-                _ => format!("WASM error (code {code}): the contract's WASM module could not be loaded or executed."),
+            Self::Wasm { code } => {
+                if let Some(detail) = crate::decode::mappings::wasm::lookup(*code) {
+                    detail.summary.to_string()
+                } else {
+                    format!("WASM error (code {code}): the contract's WASM module could not be loaded or executed.")
+                }
             },
             Self::Events { code } => match code {
                 0 => "Event size limit exceeded: the transaction emitted more event data than the protocol allows in a single execution.".to_string(),

--- a/crates/core/src/decode/mappings/mod.rs
+++ b/crates/core/src/decode/mappings/mod.rs
@@ -6,6 +6,7 @@ pub mod context;
 pub mod object;
 pub mod storage;
 pub mod value;
+pub mod wasm;
 
 #[cfg(test)]
 mod severity_tests;

--- a/crates/core/src/decode/mappings/wasm.rs
+++ b/crates/core/src/decode/mappings/wasm.rs
@@ -1,0 +1,108 @@
+use crate::types::report::Severity;
+
+/// A developer-friendly description of a single `HostError::Wasm` error code.
+///
+/// `HostError::Wasm` codes surface low-level WebAssembly execution failures —
+/// module validation errors and runtime traps such as out-of-bounds memory
+/// access. The raw codes are opaque, so this table maps each one to a short,
+/// human-readable summary of what actually went wrong inside the VM.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WasmErrorDetail {
+    pub code: u32,
+    pub name: &'static str,
+    /// Short explanation of the WebAssembly execution failure.
+    pub summary: &'static str,
+    pub severity: Severity,
+}
+
+pub const WASM_ERROR_DETAILS: &[WasmErrorDetail] = &[
+    WasmErrorDetail {
+        code: 0,
+        name: "InvalidModule",
+        summary: "Invalid WASM module: the contract bytecode failed validation — recompile with a compatible Soroban SDK version.",
+        severity: Severity::Error,
+    },
+    WasmErrorDetail {
+        code: 1,
+        name: "Unreachable",
+        summary: "WASM trap: the contract hit an `unreachable` instruction, usually from a Rust panic or a failed assertion.",
+        severity: Severity::Error,
+    },
+    WasmErrorDetail {
+        code: 2,
+        name: "MemoryAccessOutOfBounds",
+        summary: "WASM trap: the contract read or wrote linear memory outside its valid bounds (out-of-bounds memory access).",
+        severity: Severity::Error,
+    },
+    WasmErrorDetail {
+        code: 3,
+        name: "TableAccessOutOfBounds",
+        summary: "WASM trap: an indirect call referenced a function-table index that is out of bounds.",
+        severity: Severity::Error,
+    },
+    WasmErrorDetail {
+        code: 4,
+        name: "IndirectCallTypeMismatch",
+        summary: "WASM trap: an indirect call reached a function whose signature did not match the call site.",
+        severity: Severity::Error,
+    },
+    WasmErrorDetail {
+        code: 5,
+        name: "IntegerDivisionByZero",
+        summary: "WASM trap: the contract performed an integer division or remainder with a divisor of zero.",
+        severity: Severity::Error,
+    },
+    WasmErrorDetail {
+        code: 6,
+        name: "IntegerOverflow",
+        summary: "WASM trap: an integer arithmetic operation overflowed the range of its type.",
+        severity: Severity::Error,
+    },
+    WasmErrorDetail {
+        code: 7,
+        name: "InvalidConversionToInt",
+        summary: "WASM trap: a float-to-integer conversion was NaN or fell outside the target integer range.",
+        severity: Severity::Error,
+    },
+    WasmErrorDetail {
+        code: 8,
+        name: "StackOverflow",
+        summary: "WASM trap: call recursion exceeded the VM stack-depth limit (stack overflow).",
+        severity: Severity::Error,
+    },
+];
+
+pub fn lookup(code: u32) -> Option<&'static WasmErrorDetail> {
+    WASM_ERROR_DETAILS.iter().find(|detail| detail.code == code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookup_returns_out_of_bounds_memory_detail() {
+        let detail = lookup(2).expect("memory access out of bounds detail");
+        assert_eq!(detail.name, "MemoryAccessOutOfBounds");
+        assert!(detail.summary.contains("out-of-bounds memory access"));
+    }
+
+    #[test]
+    fn lookup_returns_invalid_module_for_code_zero() {
+        let detail = lookup(0).expect("invalid module detail");
+        assert_eq!(detail.name, "InvalidModule");
+    }
+
+    #[test]
+    fn table_covers_known_wasm_codes() {
+        assert_eq!(WASM_ERROR_DETAILS.len(), 9);
+        assert!(lookup(99).is_none());
+    }
+
+    #[test]
+    fn codes_are_contiguous_and_unique() {
+        for (i, detail) in WASM_ERROR_DETAILS.iter().enumerate() {
+            assert_eq!(detail.code as usize, i, "codes should be contiguous from 0");
+        }
+    }
+}

--- a/crates/core/src/taxonomy/data/wasm.toml
+++ b/crates/core/src/taxonomy/data/wasm.toml
@@ -35,3 +35,229 @@ requires_upgrade = true
 
 related_errors = []
 source_file = "soroban-env-host/src/vm.rs"
+
+[[errors]]
+id = "host.wasm.unreachable"
+category = "wasm"
+code = 1
+name = "Unreachable"
+severity = "Error"
+since_protocol = 20
+summary = "WASM trap: the contract hit an `unreachable` instruction, usually from a Rust panic or a failed assertion."
+detailed_explanation = """
+The WebAssembly VM executed an `unreachable` instruction and trapped. In Soroban contracts this is \
+almost always the result of a Rust `panic!`, a failed `assert!`/`unwrap()`/`expect()`, or an \
+explicitly unreachable branch the compiler emitted. Execution halts immediately and the whole \
+invocation is rolled back.
+"""
+[[errors.common_causes]]
+description = "A `panic!`, `unwrap()`, or `expect()` on a `None`/`Err` value inside the contract"
+likelihood = "high"
+[[errors.common_causes]]
+description = "An `assert!`/`assert_eq!` precondition that did not hold at runtime"
+likelihood = "medium"
+[[errors.suggested_fixes]]
+description = "Replace `unwrap()`/`expect()` with explicit error handling that returns a contract error"
+difficulty = "easy"
+requires_upgrade = false
+[[errors.suggested_fixes]]
+description = "Inspect the diagnostic events for the panic message to locate the failing assertion"
+difficulty = "easy"
+requires_upgrade = false
+related_errors = []
+source_file = "soroban-env-host/src/vm.rs"
+
+[[errors]]
+id = "host.wasm.memory_access_out_of_bounds"
+category = "wasm"
+code = 2
+name = "MemoryAccessOutOfBounds"
+severity = "Error"
+since_protocol = 20
+summary = "WASM trap: the contract read or wrote linear memory outside its valid bounds (out-of-bounds memory access)."
+detailed_explanation = """
+The contract attempted to load or store at a linear-memory address outside the bounds of its \
+allocated memory. The WebAssembly VM detects this and traps to prevent invalid memory access. \
+This usually indicates a bug in low-level pointer or slice handling rather than ordinary contract logic.
+"""
+[[errors.common_causes]]
+description = "Manual pointer arithmetic or `unsafe` slice handling that runs past the end of a buffer"
+likelihood = "high"
+[[errors.common_causes]]
+description = "A miscompiled contract or an incompatible/corrupted toolchain producing bad memory offsets"
+likelihood = "low"
+[[errors.suggested_fixes]]
+description = "Avoid `unsafe` memory access; use safe SDK collection types and bounds-checked accessors"
+difficulty = "medium"
+requires_upgrade = false
+[[errors.suggested_fixes]]
+description = "Rebuild the contract with a known-good Soroban SDK and toolchain version"
+difficulty = "easy"
+requires_upgrade = true
+related_errors = []
+source_file = "soroban-env-host/src/vm.rs"
+
+[[errors]]
+id = "host.wasm.table_access_out_of_bounds"
+category = "wasm"
+code = 3
+name = "TableAccessOutOfBounds"
+severity = "Error"
+since_protocol = 20
+summary = "WASM trap: an indirect call referenced a function-table index that is out of bounds."
+detailed_explanation = """
+WebAssembly resolves indirect (dynamic) calls through a function table. The contract referenced a \
+table index that does not exist, so the VM trapped. This typically points to a corrupted module or \
+a toolchain bug rather than ordinary contract logic.
+"""
+[[errors.common_causes]]
+description = "A miscompiled or corrupted WASM module with an invalid function-table layout"
+likelihood = "medium"
+[[errors.common_causes]]
+description = "Use of an incompatible compiler or post-processing tool that rewrote the function table"
+likelihood = "low"
+[[errors.suggested_fixes]]
+description = "Recompile the contract from clean sources with a supported Soroban SDK version"
+difficulty = "easy"
+requires_upgrade = true
+related_errors = []
+source_file = "soroban-env-host/src/vm.rs"
+
+[[errors]]
+id = "host.wasm.indirect_call_type_mismatch"
+category = "wasm"
+code = 4
+name = "IndirectCallTypeMismatch"
+severity = "Error"
+since_protocol = 20
+summary = "WASM trap: an indirect call reached a function whose signature did not match the call site."
+detailed_explanation = """
+An indirect call resolved to a function whose type signature differs from the one expected at the \
+call site. WebAssembly enforces signature equality for indirect calls and traps on mismatch. This \
+almost always indicates a corrupted module or a toolchain defect.
+"""
+[[errors.common_causes]]
+description = "A corrupted or miscompiled WASM module with mismatched function-type metadata"
+likelihood = "medium"
+[[errors.common_causes]]
+description = "Linking objects built with incompatible compiler or SDK versions"
+likelihood = "low"
+[[errors.suggested_fixes]]
+description = "Rebuild the contract from clean sources with a single, supported toolchain"
+difficulty = "easy"
+requires_upgrade = true
+related_errors = []
+source_file = "soroban-env-host/src/vm.rs"
+
+[[errors]]
+id = "host.wasm.integer_division_by_zero"
+category = "wasm"
+code = 5
+name = "IntegerDivisionByZero"
+severity = "Error"
+since_protocol = 20
+summary = "WASM trap: the contract performed an integer division or remainder with a divisor of zero."
+detailed_explanation = """
+The contract executed an integer division (`/`) or remainder (`%`) where the divisor evaluated to \
+zero. WebAssembly traps on integer division by zero rather than returning a value, halting the \
+invocation.
+"""
+[[errors.common_causes]]
+description = "Dividing by a quantity, balance, or supply value that can be zero"
+likelihood = "high"
+[[errors.common_causes]]
+description = "Computing a ratio or average without first checking for an empty denominator"
+likelihood = "medium"
+[[errors.suggested_fixes]]
+description = "Guard against a zero divisor and return a contract error instead of dividing"
+difficulty = "easy"
+requires_upgrade = false
+[[errors.suggested_fixes]]
+description = "Use checked arithmetic (`checked_div`) and handle the `None` case explicitly"
+difficulty = "easy"
+requires_upgrade = false
+related_errors = []
+source_file = "soroban-env-host/src/vm.rs"
+
+[[errors]]
+id = "host.wasm.integer_overflow"
+category = "wasm"
+code = 6
+name = "IntegerOverflow"
+severity = "Error"
+since_protocol = 20
+summary = "WASM trap: an integer arithmetic operation overflowed the range of its type."
+detailed_explanation = """
+An arithmetic operation produced a result outside the range of its integer type and trapped. In \
+debug builds Rust inserts overflow checks that surface here; common sources are token-amount math \
+and accumulators that exceed their type's maximum.
+"""
+[[errors.common_causes]]
+description = "Adding or multiplying token amounts that exceed the integer type's maximum"
+likelihood = "high"
+[[errors.common_causes]]
+description = "Subtracting a larger value from a smaller one in an unsigned integer"
+likelihood = "high"
+[[errors.suggested_fixes]]
+description = "Use checked or saturating arithmetic (`checked_add`, `checked_mul`) and handle overflow"
+difficulty = "easy"
+requires_upgrade = false
+[[errors.suggested_fixes]]
+description = "Use a wider integer type (e.g. `i128`/`u128`) for accumulators and amount math"
+difficulty = "medium"
+requires_upgrade = false
+related_errors = []
+source_file = "soroban-env-host/src/vm.rs"
+
+[[errors]]
+id = "host.wasm.invalid_conversion_to_int"
+category = "wasm"
+code = 7
+name = "InvalidConversionToInt"
+severity = "Error"
+since_protocol = 20
+summary = "WASM trap: a float-to-integer conversion was NaN or fell outside the target integer range."
+detailed_explanation = """
+The contract converted a floating-point value to an integer where the source was NaN, infinite, or \
+outside the representable range of the target integer type. WebAssembly traps on such truncating \
+conversions. Floating-point math is uncommon in Soroban contracts, so this usually stems from \
+imported library code.
+"""
+[[errors.common_causes]]
+description = "Converting a NaN or out-of-range floating-point value to an integer"
+likelihood = "medium"
+[[errors.common_causes]]
+description = "Pulling in a dependency that performs floating-point math internally"
+likelihood = "low"
+[[errors.suggested_fixes]]
+description = "Avoid floating-point arithmetic in contracts; use integer or fixed-point math instead"
+difficulty = "medium"
+requires_upgrade = false
+related_errors = []
+source_file = "soroban-env-host/src/vm.rs"
+
+[[errors]]
+id = "host.wasm.stack_overflow"
+category = "wasm"
+code = 8
+name = "StackOverflow"
+severity = "Error"
+since_protocol = 20
+summary = "WASM trap: call recursion exceeded the VM stack-depth limit (stack overflow)."
+detailed_explanation = """
+The contract's call depth grew beyond the WebAssembly VM's stack limit and trapped. This is caused \
+by unbounded or very deep recursion, or by large stack-allocated values pushing nested calls past \
+the limit.
+"""
+[[errors.common_causes]]
+description = "Unbounded or missing-base-case recursion in contract logic"
+likelihood = "high"
+[[errors.common_causes]]
+description = "Very deep nested calls combined with large stack-allocated values"
+likelihood = "medium"
+[[errors.suggested_fixes]]
+description = "Add a base case or depth limit to recursive functions, or rewrite them iteratively"
+difficulty = "medium"
+requires_upgrade = false
+related_errors = []
+source_file = "soroban-env-host/src/vm.rs"

--- a/crates/core/src/taxonomy/loader.rs
+++ b/crates/core/src/taxonomy/loader.rs
@@ -223,6 +223,13 @@ mod tests {
                     .map(|detail| (detail.code, detail.name))
                     .collect::<Vec<_>>(),
             ),
+            (
+                ErrorCategory::Wasm,
+                crate::decode::mappings::wasm::WASM_ERROR_DETAILS
+                    .iter()
+                    .map(|detail| (detail.code, detail.name))
+                    .collect::<Vec<_>>(),
+            ),
         ];
 
         for (category, details) in expected_codes {


### PR DESCRIPTION
Closes #266 

### Summary
Errors during WebAssembly execution (out-of-bounds memory access, integer overflow, stack overflow, etc.) previously surfaced as opaque `WASM error (code N)` messages, forcing developers to consult Stellar documentation to understand what actually trapped.

This PR maps `HostError::Wasm` error codes to developer-friendly descriptions of the WebAssembly execution failure, and bubbles those descriptions up to the transaction result view.

### Background
Prism has two parallel error-mapping systems, kept in sync by a coverage test:
- **`decode/mappings/*.rs`** (Rust tables) → consumed by `HostError::summary()` for the one-line summary.
- **`taxonomy/data/*.toml`** → loaded into `TaxonomyDatabase` → `build_report()` → `DiagnosticReport`, which is the transaction result view.

Before this change, `HostError::Wasm { code }` only handled code 0 inline and `wasm.toml` only contained code 0, so every other Wasm trap fell through to the generic fallback.

### Changes
- **New mapping table** `crates/core/src/decode/mappings/wasm.rs` (mirrors the existing `object.rs` pattern). Maps codes 0–8 to friendly summaries:
  - `0` InvalidModule
  - `1` Unreachable (Rust panic / failed assertion)
  - `2` MemoryAccessOutOfBounds (out-of-bounds memory access)
  - `3` TableAccessOutOfBounds
  - `4` IndirectCallTypeMismatch
  - `5` IntegerDivisionByZero
  - `6` IntegerOverflow
  - `7` InvalidConversionToInt
  - `8` StackOverflow
- **Registered** the module in `decode/mappings/mod.rs`.
- **Wired** `HostError::Wasm::summary()` to `mappings::wasm::lookup(code)` (same pattern as Budget/Storage/Object), preserving the existing code-0 message and generic fallback.
- **Bubbled descriptions up to the transaction result view** by adding taxonomy entries for codes 1–8 to `taxonomy/data/wasm.toml`, each with a detailed explanation, common causes, and suggested fixes — so `build_report` surfaces them in the decoded report.
- **Extended the taxonomy coverage test** in `taxonomy/loader.rs` to include Wasm, keeping the Rust table and the taxonomy data in sync.

### Behavior
A Wasm trap now decodes to an actionable message instead of `WASM error (code 2)`:

WASM trap: the contract read or wrote linear memory outside its valid bounds (out-of-bounds memory access).



### Tests
- Added 4 unit tests in `mappings/wasm.rs` (out-of-bounds lookup, code-0 InvalidModule, table size, contiguous/unique codes).
- Existing `test_summary_known_codes` and `test_summary_under_120_chars` still pass (code-0 message preserved).
- Taxonomy coverage assertions pass for all 9 Wasm codes (name match + 1–3 common causes each).
- `193` tests pass.

### Notes (pre-existing, out of scope)
While verifying, I found two pre-existing issues on `main` unrelated to this task and not touched by this PR:
1. `prism-core` does not compile on a clean `main` — `decode/contract_error.rs` imports an unregistered `decode_context` module, and the call site in `decode/mod.rs` passes `&NetworkConfig` where `&DecodeContext` is now expected (leftover from the `DecodeContext` merge). I verified this PR by temporarily patching those two lines locally, then reverted them.
2. Once it compiles, 4 tests fail due to corrupted taxonomy data: `budget.toml` and `storage.toml` are each missing one `[[errors]]` header (4 headers vs 5 codes), so `ApproachingLimit` (Budget 3) and `NearExpiry` (Storage 4) merge into the previous entry instead of parsing.

