### PR TITLE
feat: decode non_refundable_resource_fee and display in UI

### DIFF
--- a/crates/cli/src/output/renderers.rs
+++ b/crates/cli/src/output/renderers.rs
@@ -455,12 +455,12 @@ pub fn render_fee_breakdown(fee: &FeeBreakdown) -> String {
 
     if fee.resource_fee > 0 {
         out.push_str(&format!(
-            "    Refundable:       {}\n",
+            "    Refundable Resource Fee:     {}\n",
             palette.muted_text(&format_fee(fee.refundable_fee))
         ));
         out.push_str(&format!(
-            "    Non-Refundable:   {}\n",
-            palette.muted_text(&format_fee(fee.non_refundable_fee))
+            "    Non-Refundable Resource Fee: {}\n",
+            palette.muted_text(&format_fee(fee.non_refundable_resource_fee))
         ));
     }
 
@@ -575,7 +575,7 @@ mod tests {
                 inclusion_fee: 100,
                 resource_fee: 50,
                 refundable_fee: 25,
-                non_refundable_fee: 25,
+                non_refundable_resource_fee: 25,
                 bid_fee: Some(150),
             },
             resources: ResourceSummary {
@@ -601,7 +601,7 @@ mod tests {
             inclusion_fee: 100,
             resource_fee: 50,
             refundable_fee: 25,
-            non_refundable_fee: 25,
+            non_refundable_resource_fee: 25,
             bid_fee: Some(150),
         };
         let output = render_fee_breakdown(&fee);

--- a/crates/core/src/decode/context.rs
+++ b/crates/core/src/decode/context.rs
@@ -143,7 +143,7 @@ fn extract_fee_breakdown(tx_data: &serde_json::Value) -> FeeBreakdown {
         inclusion_fee,
         resource_fee,
         refundable_fee: refundable_fee + rent_fee,
-        non_refundable_fee,
+        non_refundable_resource_fee: non_refundable_fee,
         bid_fee,
     }
 }
@@ -224,7 +224,7 @@ mod tests {
         assert_eq!(breakdown.inclusion_fee, 120);
         assert_eq!(breakdown.resource_fee, 0);
         assert_eq!(breakdown.refundable_fee, 0);
-        assert_eq!(breakdown.non_refundable_fee, 0);
+        assert_eq!(breakdown.non_refundable_resource_fee, 0);
     }
 
     #[test]
@@ -282,6 +282,6 @@ mod tests {
         assert_eq!(breakdown.resource_fee, 350); // 100 + 200 + 50
         assert_eq!(breakdown.inclusion_fee, 100); // 450 - 350
         assert_eq!(breakdown.refundable_fee, 250); // 200 + 50
-        assert_eq!(breakdown.non_refundable_fee, 100);
+        assert_eq!(breakdown.non_refundable_resource_fee, 100);
     }
 }

--- a/crates/core/src/types/report.rs
+++ b/crates/core/src/types/report.rs
@@ -73,7 +73,7 @@ pub struct FeeBreakdown {
     pub inclusion_fee: i64,
     pub resource_fee: i64,
     pub refundable_fee: i64,
-    pub non_refundable_fee: i64,
+    pub non_refundable_resource_fee: i64,
     pub bid_fee: Option<i64>,
 }
 


### PR DESCRIPTION
Closes #278 