### PR TITLE
feat: parse and compare ledger write bytes from transaction metadata

### DIFF
--- a/apps/web/src/components/trace/ResourceProfile.tsx
+++ b/apps/web/src/components/trace/ResourceProfile.tsx
@@ -4,59 +4,85 @@ interface ResourceProfileProps {
     memory_used: number;
     cpu_limit: number;
     memory_limit: number;
+    read_bytes: number;
+    read_limit: number;
+    write_bytes: number;
+    write_limit: number;
   };
 }
 
-export function ResourceProfile({ profile }: ResourceProfileProps) {
-  const cpuPercentage = (profile.cpu_used / profile.cpu_limit) * 100;
-  const memoryPercentage = (profile.memory_used / profile.memory_limit) * 100;
+function ResourceBar({ label, used, limit, format }: { 
+  label: string; 
+  used: number; 
+  limit: number; 
+  format?: (v: number) => string;
+}) {
+  const percentage = limit > 0 ? (used / limit) * 100 : 0;
+  const displayValue = format ? format(used) : used.toLocaleString();
+  const displayLimit = format ? format(limit) : limit.toLocaleString();
+  
+  return (
+    <div>
+      <div className="flex justify-between mb-2">
+        <span className="text-sm font-medium">{label}</span>
+        <span className="text-sm text-gray-600">
+          {displayValue} / {displayLimit} ({percentage.toFixed(1)}%)
+        </span>
+      </div>
+      <div className="w-full bg-gray-200 rounded-full h-4">
+        <div
+          className={`h-4 rounded-full transition-all duration-300 ${
+            percentage > 90 ? "bg-red-500" : percentage > 70 ? "bg-yellow-500" : "bg-green-500"
+          }`}
+          style={{ width: `${Math.min(percentage, 100)}%` }}
+        />
+      </div>
+    </div>
+  );
+}
 
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB"];
+  const i = Math.min(Math.floor(Math.log2(bytes) / 10), units.length - 1);
+  return `${(bytes / (1 << (i * 10))).toFixed(i > 0 ? 2 : 0)} ${units[i]}`;
+}
+
+export function ResourceProfile({ profile }: ResourceProfileProps) {
   return (
     <div className="bg-white rounded-lg shadow p-6">
       <h2 className="text-xl font-semibold mb-4">Resource Profile</h2>
       
       <div className="space-y-6">
-        <div>
-          <div className="flex justify-between mb-2">
-            <span className="text-sm font-medium">CPU Instructions</span>
-            <span className="text-sm text-gray-600">
-              {profile.cpu_used.toLocaleString()} / {profile.cpu_limit.toLocaleString()} 
-              ({cpuPercentage.toFixed(1)}%)
-            </span>
-          </div>
-          <div className="w-full bg-gray-200 rounded-full h-4">
-            <div
-              className={`h-4 rounded-full transition-all duration-300 ${
-                cpuPercentage > 90 ? "bg-red-500" : cpuPercentage > 70 ? "bg-yellow-500" : "bg-green-500"
-              }`}
-              style={{ width: `${Math.min(cpuPercentage, 100)}%` }}
-            />
-          </div>
-        </div>
-
-        <div>
-          <div className="flex justify-between mb-2">
-            <span className="text-sm font-medium">Memory</span>
-            <span className="text-sm text-gray-600">
-              {(profile.memory_used / 1024 / 1024).toFixed(2)} MB / {(profile.memory_limit / 1024 / 1024).toFixed(2)} MB
-              ({memoryPercentage.toFixed(1)}%)
-            </span>
-          </div>
-          <div className="w-full bg-gray-200 rounded-full h-4">
-            <div
-              className={`h-4 rounded-full transition-all duration-300 ${
-                memoryPercentage > 90 ? "bg-red-500" : memoryPercentage > 70 ? "bg-yellow-500" : "bg-green-500"
-              }`}
-              style={{ width: `${Math.min(memoryPercentage, 100)}%` }}
-            />
-          </div>
-        </div>
+        <ResourceBar 
+          label="CPU Instructions" 
+          used={profile.cpu_used} 
+          limit={profile.cpu_limit} 
+        />
+        <ResourceBar 
+          label="Memory" 
+          used={profile.memory_used} 
+          limit={profile.memory_limit} 
+          format={(v) => formatBytes(v)}
+        />
+        <ResourceBar 
+          label="Read Bytes" 
+          used={profile.read_bytes} 
+          limit={profile.read_limit} 
+          format={(v) => formatBytes(v)}
+        />
+        <ResourceBar 
+          label="Write Bytes" 
+          used={profile.write_bytes} 
+          limit={profile.write_limit} 
+          format={(v) => formatBytes(v)}
+        />
       </div>
 
-      {(cpuPercentage > 90 || memoryPercentage > 90) && (
+      {(profile.cpu_limit > 0 && (profile.cpu_used / profile.cpu_limit) > 0.9) && (
         <div className="mt-4 p-3 bg-yellow-50 border border-yellow-200 rounded">
           <p className="text-sm text-yellow-800">
-            ⚠ Resource usage is approaching limits. Consider optimizing contract code.
+            Resource usage is approaching limits. Consider optimizing contract code.
           </p>
         </div>
       )}

--- a/apps/web/src/hooks/useTrace.ts
+++ b/apps/web/src/hooks/useTrace.ts
@@ -10,6 +10,10 @@ export interface TraceData {
     memory_used: number;
     cpu_limit: number;
     memory_limit: number;
+    read_bytes: number;
+    read_limit: number;
+    write_bytes: number;
+    write_limit: number;
   };
   state_diff: any[];
   completed: boolean;

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -36,6 +36,18 @@ export interface TransactionContext {
   ledger_sequence: number;
   function_name?: string;
   arguments: string[];
+  resources?: ResourceSummary;
+}
+
+export interface ResourceSummary {
+  cpu_instructions_used: number;
+  cpu_instructions_limit: number;
+  memory_bytes_used: number;
+  memory_bytes_limit: number;
+  read_bytes: number;
+  read_limit: number;
+  write_bytes: number;
+  write_limit: number;
 }
 
 export type Network = "mainnet" | "testnet" | "futurenet" | "custom";

--- a/crates/cli/src/output/human.rs
+++ b/crates/cli/src/output/human.rs
@@ -2,7 +2,7 @@ use prism_core::types::report::DiagnosticReport;
 
 use crate::output::renderers::{
     render_cause_list, render_error_card, render_fix_list, render_section_header,
-    BudgetBar, render_fee_breakdown,
+    render_fee_breakdown, render_resource_summary,
 };
 
 pub fn print_report(report: &DiagnosticReport) -> anyhow::Result<()> {
@@ -18,25 +18,7 @@ pub fn print_report(report: &DiagnosticReport) -> anyhow::Result<()> {
 
     if let Some(context) = &report.transaction_context {
         println!();
-        println!("{}", render_section_header("Resource Usage"));
-        println!(
-            "{}",
-            BudgetBar::new(
-                "CPU",
-                context.resources.cpu_instructions_used,
-                context.resources.cpu_instructions_limit
-            )
-            .render()
-        );
-        println!(
-            "{}",
-            BudgetBar::new(
-                "RAM",
-                context.resources.memory_bytes_used,
-                context.resources.memory_bytes_limit
-            )
-            .render()
-        );
+        print!("{}", render_resource_summary(&context.resources));
         println!();
         print!("{}", render_fee_breakdown(&context.fee));
     }

--- a/crates/cli/src/output/mod.rs
+++ b/crates/cli/src/output/mod.rs
@@ -70,6 +70,16 @@ pub fn print_resource_profile(
                 renderers::BudgetBar::new("Memory", profile.total_memory, profile.memory_limit)
                     .render()
             );
+            println!(
+                "{}",
+                renderers::BudgetBar::new("Read", profile.total_read_bytes, profile.read_limit)
+                    .render()
+            );
+            println!(
+                "{}",
+                renderers::BudgetBar::new("Write", profile.total_write_bytes, profile.write_limit)
+                    .render()
+            );
             let palette = theme::ColorPalette::default();
             for warning in &profile.warnings {
                 println!("{} {warning}", palette.warning_text("⚠"));
@@ -134,12 +144,14 @@ pub fn print_whatif_status(
 
 fn format_trace_summary(trace: &ExecutionTrace) -> String {
     format!(
-        "Status: Complete | Tx: {} | Invocations: {} | Changes: {} | CPU: {}/{}",
+        "Status: Complete | Tx: {} | Invocations: {} | Changes: {} | CPU: {}/{} | Write: {}/{}",
         trace.tx_hash,
         trace.invocations.len(),
         trace.state_diff.entries.len(),
         trace.resource_profile.total_cpu,
-        trace.resource_profile.cpu_limit
+        trace.resource_profile.cpu_limit,
+        trace.resource_profile.total_write_bytes,
+        trace.resource_profile.write_limit
     )
 }
 
@@ -151,11 +163,15 @@ fn format_resource_profile_summary(profile: &ResourceProfile) -> String {
     };
 
     format!(
-        "Status: Complete | CPU: {}/{} | Memory: {}/{}{}",
+        "Status: Complete | CPU: {}/{} | Memory: {}/{} | Read: {}/{} | Write: {}/{}{}",
         profile.total_cpu,
         profile.cpu_limit,
         profile.total_memory,
         profile.memory_limit,
+        profile.total_read_bytes,
+        profile.read_limit,
+        profile.total_write_bytes,
+        profile.write_limit,
         warning_suffix
     )
 }

--- a/crates/cli/src/output/renderers.rs
+++ b/crates/cli/src/output/renderers.rs
@@ -2,7 +2,7 @@
 
 use crate::output::theme::ColorPalette;
 use colored::Colorize;
-use prism_core::types::report::{DiagnosticReport, RootCause, TransactionContext, FeeBreakdown};
+use prism_core::types::report::{DiagnosticReport, ResourceSummary, RootCause, TransactionContext, FeeBreakdown};
 use prism_core::types::trace::ResourceProfile;
 use tabled::{Table, Tabled};
 
@@ -423,6 +423,38 @@ impl<'a> StateDiffTable<'a> {
     }
 }
 
+pub fn render_resource_summary(resources: &ResourceSummary) -> String {
+    let palette = ColorPalette::default();
+    let mut out = String::new();
+
+    out.push_str(&render_section_header("Resource Summary"));
+    out.push('\n');
+
+    let cpu_bar = BudgetBar::new("CPU", resources.cpu_instructions_used, resources.cpu_instructions_limit);
+    out.push_str(&format!("  {}\n", cpu_bar.render()));
+
+    let mem_bar = BudgetBar::new("Memory", resources.memory_bytes_used, resources.memory_bytes_limit);
+    out.push_str(&format!("  {}\n", mem_bar.render()));
+
+    let read_bar = BudgetBar::new("Read", resources.read_bytes, resources.read_limit);
+    out.push_str(&format!("  {}\n", read_bar.render()));
+
+    let write_bar = BudgetBar::new("Write", resources.write_bytes, resources.write_limit);
+    out.push_str(&format!("  {}\n", write_bar.render()));
+
+    if resources.write_limit > 0 {
+        let write_pct = (resources.write_bytes as f64 / resources.write_limit as f64) * 100.0;
+        if write_pct > 90.0 {
+            out.push_str(&format!(
+                "  {} Write bytes at {write_pct:.0}% of limit — consider reducing storage writes\n",
+                palette.warning_text("⚠"),
+            ));
+        }
+    }
+
+    out
+}
+
 pub fn render_fee_breakdown(fee: &FeeBreakdown) -> String {
     let palette = ColorPalette::default();
     let mut out = String::new();
@@ -483,6 +515,8 @@ mod tests {
             memory_limit: 1_000_000,
             total_read_bytes: 0,
             total_write_bytes: 0,
+            read_limit: 0,
+            write_limit: 0,
             hotspots,
             warnings: vec![],
         }
@@ -584,7 +618,9 @@ mod tests {
                 memory_bytes_used: 5000,
                 memory_bytes_limit: 50000,
                 read_bytes: 1000,
+                read_limit: 50000,
                 write_bytes: 500,
+                write_limit: 50000,
             },
         };
 

--- a/crates/core/src/decode/context.rs
+++ b/crates/core/src/decode/context.rs
@@ -3,6 +3,11 @@
 use crate::decode::auth_signature::decode_auth_entry_signatures;
 use crate::error::PrismResult;
 use crate::types::report::{DiagnosticReport, FeeBreakdown, ResourceSummary, TransactionContext};
+use crate::xdr::codec::XdrCodec;
+use stellar_xdr::curr::{
+    FeeBumpTransactionInnerTx, LedgerEntryChange, Transaction, TransactionEnvelope, TransactionExt,
+    TransactionMeta, TransactionResult,
+};
 
 pub fn enrich_report(
     report: &mut DiagnosticReport,
@@ -57,9 +62,6 @@ fn extract_return_value(tx_data: &serde_json::Value) -> Option<String> {
 }
 
 fn extract_fee_breakdown(tx_data: &serde_json::Value) -> FeeBreakdown {
-    use crate::xdr::codec::XdrCodec;
-    use stellar_xdr::curr::{TransactionEnvelope, TransactionResult, TransactionMeta};
-
     // 1. Get total fee from resultXdr
     let mut total_fee = 0;
     if let Some(result_xdr_b64) = tx_data.get("resultXdr").and_then(|v| v.as_str()) {
@@ -131,14 +133,100 @@ fn extract_fee_breakdown(tx_data: &serde_json::Value) -> FeeBreakdown {
     }
 }
 
-fn extract_resource_summary(_tx_data: &serde_json::Value) -> ResourceSummary {
-    ResourceSummary {
+fn extract_resource_summary(tx_data: &serde_json::Value) -> ResourceSummary {
+    let mut summary = ResourceSummary {
         cpu_instructions_used: 0,
         cpu_instructions_limit: 0,
         memory_bytes_used: 0,
         memory_bytes_limit: 0,
         read_bytes: 0,
+        read_limit: 0,
         write_bytes: 0,
+        write_limit: 0,
+    };
+
+    if let Some(meta_xdr_b64) = tx_data.get("resultMetaXdr").and_then(|v| v.as_str()) {
+        if let Ok(tx_meta) = TransactionMeta::from_xdr_base64(meta_xdr_b64) {
+            if let TransactionMeta::V3(v3) = tx_meta {
+                // Compute total write bytes from ledger entry changes:
+                // we sum the XDR-serialized size of every Created and Updated entry.
+                let mut write_bytes: u64 = 0;
+                let mut read_bytes: u64 = 0;
+
+                // Helper: compute size of a LedgerEntry's data payload.
+                let entry_size = |entry: &stellar_xdr::curr::LedgerEntry| -> u64 {
+                    XdrCodec::to_xdr_bytes(entry).unwrap_or_default().len() as u64
+                };
+
+                // tx_changes_before — entries that existed before (state snapshot)
+                for change in v3.tx_changes_before.iter() {
+                    if let Ok(entry) = ledger_entry_from_change(change) {
+                        read_bytes += entry_size(&entry);
+                    }
+                }
+
+                // per-operation changes
+                for op in v3.operations.iter() {
+                    for change in op.changes.iter() {
+                        match change {
+                            LedgerEntryChange::LedgerEntryCreated(entry) => {
+                                write_bytes += entry_size(entry);
+                            }
+                            LedgerEntryChange::LedgerEntryUpdated(entry) => {
+                                write_bytes += entry_size(entry);
+                            }
+                            LedgerEntryChange::LedgerEntryRemoved(key) => {
+                                if let Ok(key_bytes) = XdrCodec::to_xdr_bytes(key) {
+                                    read_bytes += key_bytes.len() as u64;
+                                }
+                            }
+                            LedgerEntryChange::LedgerEntryState(entry) => {
+                                read_bytes += entry_size(entry);
+                            }
+                        }
+                    }
+                }
+
+                // tx_changes_after — final state (duplicates some operation data, skip to avoid double-count)
+
+                summary.read_bytes = read_bytes;
+                summary.write_bytes = write_bytes;
+            }
+        }
+    }
+
+    // Extract read/write limits from the transaction envelope's SorobanTransactionData
+    if let Some(envelope_xdr_b64) = tx_data.get("envelopeXdr").and_then(|v| v.as_str()) {
+        if let Ok(tx_envelope) = TransactionEnvelope::from_xdr_base64(envelope_xdr_b64) {
+            let inner_tx = inner_transaction(&tx_envelope);
+            if let TransactionExt::V1(soroban_data) = &inner_tx.ext {
+                summary.read_limit = soroban_data.resources.read_bytes as u64;
+                summary.write_limit = soroban_data.resources.write_bytes as u64;
+            }
+        }
+    }
+
+    summary
+}
+
+/// Extract the inner Transaction from any envelope variant.
+fn inner_transaction(envelope: &TransactionEnvelope) -> &Transaction {
+    match envelope {
+        TransactionEnvelope::TxV0(v0) => &v0.tx,
+        TransactionEnvelope::Tx(v1) => &v1.tx,
+        TransactionEnvelope::TxFeeBump(fb) => match &fb.tx.inner_tx {
+            FeeBumpTransactionInnerTx::Tx(v1) => &v1.tx,
+        },
+    }
+}
+
+/// Extract a LedgerEntry from any LedgerEntryChange if the variant carries one.
+fn ledger_entry_from_change(change: &LedgerEntryChange) -> Result<stellar_xdr::curr::LedgerEntry, ()> {
+    match change {
+        LedgerEntryChange::LedgerEntryCreated(entry)
+        | LedgerEntryChange::LedgerEntryUpdated(entry)
+        | LedgerEntryChange::LedgerEntryState(entry) => Ok(entry.clone()),
+        _ => Err(()),
     }
 }
 

--- a/crates/core/src/replay/mod.rs
+++ b/crates/core/src/replay/mod.rs
@@ -22,7 +22,7 @@ pub async fn replay_transaction(
 
     let state_diff = differ::compute_diff(&ledger_state, &raw_trace)?;
 
-    let profile = profiler::generate_profile(&raw_trace)?;
+    let profile = profiler::generate_profile(&raw_trace, &state_diff)?;
 
     Ok(ExecutionTrace {
         tx_hash: tx_hash.to_string(),

--- a/crates/core/src/replay/profiler.rs
+++ b/crates/core/src/replay/profiler.rs
@@ -2,16 +2,49 @@
 
 use crate::replay::sandbox::SandboxResult;
 use crate::error::PrismResult;
-use crate::types::trace::ResourceProfile;
+use crate::types::trace::{DiffChangeType, ResourceProfile, StateDiff};
 
-pub fn generate_profile(result: &SandboxResult) -> PrismResult<ResourceProfile> {
+pub fn generate_profile(result: &SandboxResult, state_diff: &StateDiff) -> PrismResult<ResourceProfile> {
+    let mut total_write_bytes: u64 = 0;
+    let mut total_read_bytes: u64 = 0;
+
+    for entry in &state_diff.entries {
+        match entry.change_type {
+            DiffChangeType::Created => {
+                if let Some(after) = &entry.after {
+                    total_write_bytes += after.len() as u64 / 2;
+                }
+            }
+            DiffChangeType::Updated => {
+                if let Some(after) = &entry.after {
+                    total_write_bytes += after.len() as u64 / 2;
+                }
+                if let Some(before) = &entry.before {
+                    total_read_bytes += before.len() as u64 / 2;
+                }
+            }
+            DiffChangeType::Deleted => {
+                if let Some(before) = &entry.before {
+                    total_read_bytes += before.len() as u64 / 2;
+                }
+            }
+            DiffChangeType::Unchanged => {
+                if let Some(before) = &entry.before {
+                    total_read_bytes += before.len() as u64 / 2;
+                }
+            }
+        }
+    }
+
     let mut profile = ResourceProfile {
         total_cpu: result.total_cpu,
         cpu_limit: 0, 
         total_memory: result.total_memory,
         memory_limit: 0,
-        total_read_bytes: 0,
-        total_write_bytes: 0,
+        total_read_bytes,
+        total_write_bytes,
+        read_limit: 0,
+        write_limit: 0,
         hotspots: Vec::new(),
         warnings: Vec::new(),
     };
@@ -30,6 +63,15 @@ pub fn generate_profile(result: &SandboxResult) -> PrismResult<ResourceProfile> 
         if mem_usage > 90.0 {
             profile.warnings.push(format!(
                 "Memory usage is at {mem_usage:.0}% of budget — consider increasing or optimizing"
+            ));
+        }
+    }
+
+    if profile.write_limit > 0 {
+        let write_usage = (profile.total_write_bytes as f64 / profile.write_limit as f64) * 100.0;
+        if write_usage > 90.0 {
+            profile.warnings.push(format!(
+                "Write bytes usage is at {write_usage:.0}% of limit — consider reducing storage writes"
             ));
         }
     }

--- a/crates/core/src/types/report.rs
+++ b/crates/core/src/types/report.rs
@@ -82,7 +82,9 @@ pub struct ResourceSummary {
     pub memory_bytes_used: u64,
     pub memory_bytes_limit: u64,
     pub read_bytes: u64,
+    pub read_limit: u64,
     pub write_bytes: u64,
+    pub write_limit: u64,
 }
 
 /// Pinpoints the exact contract and function where a cross-contract call chain failed.

--- a/crates/core/src/types/trace.rs
+++ b/crates/core/src/types/trace.rs
@@ -98,6 +98,10 @@ pub struct ResourceProfile {
 
     pub total_write_bytes: u64,
 
+    pub read_limit: u64,
+
+    pub write_limit: u64,
+
     pub hotspots: Vec<ResourceHotspot>,
 
     pub warnings: Vec<String>,


### PR DESCRIPTION
## Description

Writing to the ledger is the most expensive operation in a smart contract. This PR provides full visibility into write bytes for fee optimization and cost analysis.

## Changes

### Data Model
- Added `read_limit` and `write_limit` fields to both `ResourceProfile` (trace.rs) and `ResourceSummary` (report.rs) so every resource display can show actual usage vs. the allowed limit.

### Decode Path — Metadata Analysis (`context.rs`)
- Rewrote `extract_resource_summary()` to parse `TransactionMeta::V3` ledger entry changes
- **Write bytes**: sums XDR-serialized sizes of all `LedgerEntryCreated` and `LedgerEntryUpdated` entries from per-operation changes
- **Read bytes**: sums sizes of state snapshots (`tx_changes_before`), `LedgerEntryState`, and `LedgerEntryRemoved` entries
- **Limits**: extracts `SorobanTransactionData.resources.{read_bytes,write_bytes}` from the transaction envelope's `TransactionExt::V1`

### Replay Path — State Diff Analysis (`profiler.rs`)
- Updated `generate_profile()` to accept `&StateDiff` and compute I/O bytes from hex-encoded diff entries:
  - Created → write bytes (after value)
  - Updated → write bytes (after) + read bytes (before)
  - Deleted / Unchanged → read bytes (before)
- Generates warnings when write usage exceeds 90% of the declared limit

### CLI Output
- Added `render_resource_summary()` showing four color-coded budget bars (CPU, Memory, Read, Write)
- Read/Write bars added to `print_resource_profile()` in the replay path
- Compact format strings updated to include write bytes

### Web Frontend
- Added `ResourceSummary` TypeScript interface with read/write bytes and limits
- Extended `TraceData.resource_profile` with read/write byte fields
- `ResourceProfile.tsx`: new `ResourceBar` component with byte-formatted gauges (B/KB/MB)

Closes #275