### PR TITLE
feat: map standard HostError::Contract codes to human-readable descri…

### DIFF
--- a/apps/web/src/app/decode/page.tsx
+++ b/apps/web/src/app/decode/page.tsx
@@ -1,7 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import { Header, Footer, DecodeForm, ErrorCard, ContractErrorView } from "@/components";
+import type { DiagnosticReport } from "@/lib/types";
+
 export default function DecodePage() {
+  const [activeTab, setActiveTab] = useState<"diagnose" | "lookup">("diagnose");
+  const [report, setReport] = useState<DiagnosticReport | null>(null);
+
   return (
-    <main>
-      <h1>Decode Transaction</h1>
-    </main>
+    <div className="min-h-screen bg-slate-950 text-slate-100 flex flex-col selection:bg-violet-500/30 selection:text-violet-200">
+      <Header />
+
+      <main className="flex-1 max-w-5xl w-full mx-auto px-4 py-8 md:py-12">
+        <div className="text-center mb-10">
+          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-violet-950/40 border border-violet-800/40 text-violet-300 text-xs font-medium mb-4 animate-pulse">
+            <span>🔬</span> Soroban Transaction Debugger
+          </div>
+          <h1 className="text-3xl md:text-5xl font-extrabold tracking-tight bg-gradient-to-r from-slate-100 via-violet-200 to-violet-400 bg-clip-text text-transparent mb-4">
+            Decode Transaction Errors
+          </h1>
+          <p className="text-slate-400 max-w-xl mx-auto text-base md:text-lg">
+            Diagnose cryptic Soroban execution failures, map raw error codes, and find suggested remedies instantly.
+          </p>
+        </div>
+
+        {/* Tab Navigation */}
+        <div className="flex justify-center border-b border-slate-800 mb-8 max-w-md mx-auto">
+          <button
+            onClick={() => setActiveTab("diagnose")}
+            className={`flex-1 pb-3 text-sm font-semibold transition-all focus:outline-none border-b-2 ${
+              activeTab === "diagnose"
+                ? "text-violet-400 border-violet-500"
+                : "text-slate-500 border-transparent hover:text-slate-300"
+            }`}
+          >
+            🔍 Diagnose Error
+          </button>
+          <button
+            onClick={() => setActiveTab("lookup")}
+            className={`flex-1 pb-3 text-sm font-semibold transition-all focus:outline-none border-b-2 ${
+              activeTab === "lookup"
+                ? "text-violet-400 border-violet-500"
+                : "text-slate-500 border-transparent hover:text-slate-300"
+            }`}
+          >
+            📋 Contract Error Reference
+          </button>
+        </div>
+
+        {/* Tab Content */}
+        <div className="transition-all duration-300">
+          {activeTab === "diagnose" ? (
+            <div className="space-y-6">
+              <DecodeForm onDecode={setReport} />
+              {report && (
+                <div className="animate-in fade-in slide-in-from-bottom-4 duration-500">
+                  <ErrorCard report={report} />
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="animate-in fade-in slide-in-from-bottom-4 duration-500">
+              <ContractErrorView />
+            </div>
+          )}
+        </div>
+      </main>
+
+      <Footer />
+    </div>
   );
 }

--- a/apps/web/src/components/decode/ContractErrorView.tsx
+++ b/apps/web/src/components/decode/ContractErrorView.tsx
@@ -1,3 +1,280 @@
+"use client";
+
+import { useState } from "react";
+
+interface ContractErrorDetail {
+  code: number;
+  name: string;
+  summary: string;
+  description: string;
+  causes: string[];
+  fixes: string[];
+}
+
+const standardContractErrors: Record<number, ContractErrorDetail> = {
+  0: {
+    code: 0,
+    name: "ContractError",
+    summary: "The contract's own logic rejected this call.",
+    description: "Unlike host errors, contract errors are defined by the contract author. When a contract panics or returns an error value, the host wraps it as a ContractError with code 0 or the custom code.",
+    causes: [
+      "Business logic assertion failure in the contract (e.g., insufficient balance, invalid state)",
+      "Input validation failure — the contract rejected the provided arguments",
+      "Access control check failed — the caller is not authorized for this operation"
+    ],
+    fixes: [
+      "Use prism's contract error resolver to map the numeric code to the contract's error enum name",
+      "Review the contract source code for the error enum definition to understand the specific failure"
+    ]
+  },
+  1: {
+    code: 1,
+    name: "InternalError",
+    summary: "An internal protocol implementation error occurred (e.g. invalid ledger state).",
+    description: "The contract encountered an internal error during execution, indicating a protocol implementation issue or invalid ledger state.",
+    causes: [
+      "Internal validation or state consistency checks failed in the contract"
+    ],
+    fixes: [
+      "Check the diagnostic logs to see if there are internal contract assertion failures"
+    ]
+  },
+  2: {
+    code: 2,
+    name: "OperationNotSupportedError",
+    summary: "The operation is not supported (e.g. calling clawback on an asset without clawback enabled).",
+    description: "The contract attempted an operation that is unsupported by the contract configuration or type (e.g., performing a clawback on an asset when clawback is disabled).",
+    causes: [
+      "Invoking clawback on a non-clawbackable asset"
+    ],
+    fixes: [
+      "Check the asset flags and ensure the operation is allowed for the target asset"
+    ]
+  },
+  3: {
+    code: 3,
+    name: "AlreadyInitializedError",
+    summary: "The contract instance has already been initialized and cannot be re-initialized.",
+    description: "The contract instance was initialized twice. Soroban contracts typically only allow initialization once.",
+    causes: [
+      "Calling the initialize function on an already initialized contract instance"
+    ],
+    fixes: [
+      "Ensure that initialization is only called once per contract deployment"
+    ]
+  },
+  6: {
+    code: 6,
+    name: "AccountMissingError",
+    summary: "An account involved in the transaction does not exist on the network.",
+    description: "The operation required a specific account to exist on the network, but the account could not be found.",
+    causes: [
+      "Providing an invalid account address or an account that has not been created/funded"
+    ],
+    fixes: [
+      "Verify that the addresses provided exist and are active on the target network"
+    ]
+  }
+};
+
 export default function ContractErrorView() {
-  return <div>{/* Contract-specific error resolution */}</div>;
+  const [selectedCode, setSelectedCode] = useState<number>(0);
+  const [customCode, setCustomCode] = useState<string>("");
+  const [isCustomMode, setIsCustomMode] = useState<boolean>(false);
+
+  const activeError = isCustomMode
+    ? standardContractErrors[parseInt(customCode)]
+    : standardContractErrors[selectedCode];
+
+  const handleCustomCodeChange = (val: string) => {
+    setCustomCode(val);
+    setIsCustomMode(val.trim() !== "");
+  };
+
+  return (
+    <div className="bg-slate-900 border border-slate-800 rounded-xl p-6 shadow-xl max-w-3xl mx-auto my-6 text-slate-100">
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-xl font-bold tracking-tight text-violet-400">
+          📋 Contract Error Lookup
+        </h2>
+        <span className="text-xs px-2.5 py-1 rounded-full bg-violet-950/50 border border-violet-800/50 text-violet-300 font-mono">
+          HostError::Contract
+        </span>
+      </div>
+
+      <p className="text-sm text-slate-400 mb-6">
+        Soroban smart contracts return numeric codes when they revert. Select a standard code or enter a custom code to view its details.
+      </p>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+        <div>
+          <label className="block text-xs font-semibold text-slate-400 uppercase tracking-wider mb-2">
+            Select Standard Code
+          </label>
+          <select
+            value={selectedCode}
+            onChange={(e) => {
+              setSelectedCode(Number(e.target.value));
+              setIsCustomMode(false);
+              setCustomCode("");
+            }}
+            className="w-full bg-slate-950 border border-slate-800 rounded-lg px-3 py-2 text-slate-200 focus:outline-none focus:border-violet-500 transition-colors"
+          >
+            {Object.values(standardContractErrors).map((err) => (
+              <option key={err.code} value={err.code}>
+                Code {err.code}: {err.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-xs font-semibold text-slate-400 uppercase tracking-wider mb-2">
+            Or Type Any Code
+          </label>
+          <input
+            type="number"
+            value={customCode}
+            onChange={(e) => handleCustomCodeChange(e.target.value)}
+            placeholder="e.g. 42"
+            className="w-full bg-slate-950 border border-slate-800 rounded-lg px-3 py-2 text-slate-200 placeholder-slate-600 focus:outline-none focus:border-violet-500 transition-colors"
+          />
+        </div>
+      </div>
+
+      {activeError ? (
+        <div className="border-t border-slate-800 pt-6">
+          <div className="flex items-start justify-between mb-4">
+            <div>
+              <span className="text-xs font-bold text-violet-400 uppercase tracking-wider">
+                Category: Contract
+              </span>
+              <h3 className="text-lg font-bold text-slate-100 flex items-center gap-2 mt-1">
+                {activeError.name}
+                <span className="text-sm font-mono text-slate-500 bg-slate-950 px-2 py-0.5 rounded border border-slate-800">
+                  Code {activeError.code}
+                </span>
+              </h3>
+            </div>
+            <span className="text-xs px-2.5 py-1 rounded bg-red-950/40 border border-red-900/50 text-red-400 font-medium">
+              Error
+            </span>
+          </div>
+
+          <div className="bg-slate-950 rounded-lg p-4 border border-slate-800 mb-4">
+            <h4 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-1">
+              Summary
+            </h4>
+            <p className="text-slate-300 text-sm">{activeError.summary}</p>
+          </div>
+
+          <div className="mb-4">
+            <h4 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-1">
+              Detailed Explanation
+            </h4>
+            <p className="text-slate-400 text-sm leading-relaxed">
+              {activeError.description}
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
+            <div>
+              <h4 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2">
+                Common Causes
+              </h4>
+              <ul className="space-y-2">
+                {activeError.causes.map((cause, i) => (
+                  <li key={i} className="text-sm text-slate-300 flex items-start gap-2">
+                    <span className="text-red-400 mt-1">•</span>
+                    <span>{cause}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div>
+              <h4 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2">
+                Suggested Fixes
+              </h4>
+              <ul className="space-y-2">
+                {activeError.fixes.map((fix, i) => (
+                  <li key={i} className="text-sm text-slate-300 flex items-start gap-2">
+                    <span className="text-emerald-400 mt-1">✓</span>
+                    <span>{fix}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      ) : isCustomMode && customCode.trim() !== "" ? (
+        <div className="border-t border-slate-800 pt-6">
+          <div className="flex items-start justify-between mb-4">
+            <div>
+              <span className="text-xs font-bold text-amber-400 uppercase tracking-wider">
+                Category: Contract (Custom)
+              </span>
+              <h3 className="text-lg font-bold text-slate-100 flex items-center gap-2 mt-1">
+                CustomContractError
+                <span className="text-sm font-mono text-slate-500 bg-slate-950 px-2 py-0.5 rounded border border-slate-800">
+                  Code {customCode}
+                </span>
+              </h3>
+            </div>
+            <span className="text-xs px-2.5 py-1 rounded bg-red-950/40 border border-red-900/50 text-red-400 font-medium">
+              Error
+            </span>
+          </div>
+
+          <div className="bg-slate-950 rounded-lg p-4 border border-slate-800 mb-4">
+            <h4 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-1">
+              Summary
+            </h4>
+            <p className="text-slate-300 text-sm">
+              The contract reverted with custom error code {customCode}.
+            </p>
+          </div>
+
+          <div className="mb-4">
+            <h4 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-1">
+              Detailed Explanation
+            </h4>
+            <p className="text-slate-400 text-sm leading-relaxed">
+              This is a custom contract-defined error code. Custom error codes are defined by the contract author inside their `#[contracterror]` enum. To map this code to its name, you need the contract's WASM specification or source code.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
+            <div>
+              <h4 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2">
+                Common Causes
+              </h4>
+              <ul className="space-y-2">
+                <li className="text-sm text-slate-300 flex items-start gap-2">
+                  <span className="text-red-400 mt-1">•</span>
+                  <span>A business logic requirement or assertion in the contract was not met.</span>
+                </li>
+              </ul>
+            </div>
+
+            <div>
+              <h4 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2">
+                Suggested Fixes
+              </h4>
+              <ul className="space-y-2">
+                <li className="text-sm text-slate-300 flex items-start gap-2">
+                  <span className="text-emerald-400 mt-1">✓</span>
+                  <span>Locate the source code of the contract and find its `#[contracterror]` enum.</span>
+                </li>
+                <li className="text-sm text-slate-300 flex items-start gap-2">
+                  <span className="text-emerald-400 mt-1">✓</span>
+                  <span>Match the numeric code {customCode} with the integer values assigned to the enum variants.</span>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
 }

--- a/apps/web/src/components/decode/DecodeForm.tsx
+++ b/apps/web/src/components/decode/DecodeForm.tsx
@@ -1,3 +1,165 @@
-export default function DecodeForm() {
-  return <form>{/* TX hash input + diagnose button */}</form>;
+"use client";
+
+import { useState } from "react";
+import type { DiagnosticReport } from "@/lib/types";
+
+interface DecodeFormProps {
+  onDecode: (report: DiagnosticReport | null) => void;
+}
+
+export default function DecodeForm({ onDecode }: DecodeFormProps) {
+  const [category, setCategory] = useState<string>("contract");
+  const [code, setCode] = useState<string>("0");
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  // Client-side mapping of standard errors for instant UI response and verification
+  const mockDecode = (cat: string, codeVal: number): DiagnosticReport => {
+    switch (cat.toLowerCase()) {
+      case "contract":
+        if (codeVal === 1) {
+          return {
+            error_category: "Contract",
+            error_code: 1,
+            error_name: "InternalError",
+            summary: "An internal protocol implementation error occurred (e.g. invalid ledger state).",
+            detailed_explanation: "The contract encountered an internal error during execution, indicating a protocol implementation issue or invalid ledger state.",
+            severity: "error",
+            root_causes: [{ description: "Internal validation or state consistency checks failed in the contract", likelihood: "high" }],
+            suggested_fixes: [{ description: "Check the diagnostic logs to see if there are internal contract assertion failures", difficulty: "medium", requires_upgrade: false }]
+          };
+        } else if (codeVal === 2) {
+          return {
+            error_category: "Contract",
+            error_code: 2,
+            error_name: "OperationNotSupportedError",
+            summary: "The operation is not supported (e.g. calling clawback on an asset without clawback enabled).",
+            detailed_explanation: "The contract attempted an operation that is unsupported by the contract configuration or type (e.g., performing a clawback on an asset when clawback is disabled).",
+            severity: "error",
+            root_causes: [{ description: "Invoking clawback on a non-clawbackable asset", likelihood: "high" }],
+            suggested_fixes: [{ description: "Check the asset flags and ensure the operation is allowed for the target asset", difficulty: "easy", requires_upgrade: false }]
+          };
+        } else if (codeVal === 3) {
+          return {
+            error_category: "Contract",
+            error_code: 3,
+            error_name: "AlreadyInitializedError",
+            summary: "The contract instance has already been initialized and cannot be re-initialized.",
+            detailed_explanation: "The contract instance was initialized twice. Soroban contracts typically only allow initialization once.",
+            severity: "error",
+            root_causes: [{ description: "Calling the initialize function on an already initialized contract instance", likelihood: "high" }],
+            suggested_fixes: [{ description: "Ensure that initialization is only called once per contract deployment", difficulty: "easy", requires_upgrade: false }]
+          };
+        } else if (codeVal === 6) {
+          return {
+            error_category: "Contract",
+            error_code: 6,
+            error_name: "AccountMissingError",
+            summary: "An account involved in the transaction does not exist on the network.",
+            detailed_explanation: "The operation required a specific account to exist on the network, but the account could not be found.",
+            severity: "error",
+            root_causes: [{ description: "Providing an invalid account address or an account that has not been created/funded", likelihood: "high" }],
+            suggested_fixes: [{ description: "Verify that the addresses provided exist and are active on the target network", difficulty: "easy", requires_upgrade: false }]
+          };
+        } else {
+          return {
+            error_category: "Contract",
+            error_code: codeVal,
+            error_name: "ContractError",
+            summary: "Contract error: the contract's own logic rejected this call — run with --resolve to map the code to its name.",
+            detailed_explanation: "Unlike host errors, contract errors are defined by the contract author. Each contract can define an error enum with numeric codes and descriptive names. When a contract panics or returns an error value, the host wraps it as a ContractError with the numeric code.",
+            severity: "error",
+            root_causes: [{ description: "Business logic assertion failure in the contract", likelihood: "high" }],
+            suggested_fixes: [{ description: "Review the contract source code for the error enum definition to understand the specific failure", difficulty: "medium", requires_upgrade: false }]
+          };
+        }
+
+      case "budget":
+        return {
+          error_category: "Budget",
+          error_code: codeVal,
+          error_name: "CpuLimitExceeded",
+          summary: "CPU limit exceeded: the transaction ran out of CPU instructions before completing execution.",
+          detailed_explanation: "The transaction exceeded its CPU instruction budget. Each transaction has a fixed CPU budget limits defined by the protocol to prevent infinite loops.",
+          severity: "fatal",
+          root_causes: [{ description: "Infinite loops or excessive complexity in contract execution path", likelihood: "high" }],
+          suggested_fixes: [{ description: "Optimize contract code and reduce loop count", difficulty: "medium", requires_upgrade: false }]
+        };
+
+      default:
+        return {
+          error_category: cat.toUpperCase(),
+          error_code: codeVal,
+          error_name: "UnknownError",
+          summary: `An unknown error occurred in category ${cat}.`,
+          detailed_explanation: "This error code and category combination is not registered as a standard host error or contract error.",
+          severity: "error",
+          root_causes: [],
+          suggested_fixes: []
+        };
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setTimeout(() => {
+      const decodedReport = mockDecode(category, Number(code));
+      onDecode(decodedReport);
+      setIsLoading(false);
+    }, 500);
+  };
+
+  return (
+    <div className="bg-slate-900 border border-slate-800 rounded-xl p-6 shadow-xl max-w-3xl mx-auto my-6 text-slate-100">
+      <h2 className="text-xl font-bold tracking-tight text-violet-400 mb-4">
+        🔎 Decode Error Code
+      </h2>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-xs font-semibold text-slate-400 uppercase tracking-wider mb-2">
+              Error Category
+            </label>
+            <select
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              className="w-full bg-slate-950 border border-slate-800 rounded-lg px-3 py-2.5 text-slate-200 focus:outline-none focus:border-violet-500 transition-colors"
+            >
+              <option value="contract">Contract (HostError::Contract)</option>
+              <option value="budget">Budget (HostError::Budget)</option>
+              <option value="storage">Storage (HostError::Storage)</option>
+              <option value="auth">Auth (HostError::Auth)</option>
+              <option value="value">Value (HostError::Value)</option>
+              <option value="wasm">Wasm (HostError::Wasm)</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-xs font-semibold text-slate-400 uppercase tracking-wider mb-2">
+              Error Code (Numeric)
+            </label>
+            <input
+              type="number"
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              placeholder="e.g. 1"
+              min="0"
+              className="w-full bg-slate-950 border border-slate-800 rounded-lg px-3 py-2.5 text-slate-200 placeholder-slate-600 focus:outline-none focus:border-violet-500 transition-colors"
+            />
+          </div>
+        </div>
+
+        <div className="flex justify-end pt-2">
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="bg-violet-600 hover:bg-violet-500 text-white font-medium px-6 py-2.5 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 focus:ring-offset-slate-900 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isLoading ? "Decoding..." : "Diagnose Error"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
 }

--- a/apps/web/src/components/decode/ErrorCard.tsx
+++ b/apps/web/src/components/decode/ErrorCard.tsx
@@ -1,3 +1,116 @@
-export default function ErrorCard() {
-  return <div>{/* Decoded error with root cause */}</div>;
+"use client";
+
+import type { DiagnosticReport } from "@/lib/types";
+
+interface ErrorCardProps {
+  report: DiagnosticReport;
+}
+
+export default function ErrorCard({ report }: ErrorCardProps) {
+  const getSeverityStyles = (severity: string) => {
+    switch (severity.toLowerCase()) {
+      case "fatal":
+        return "bg-red-950/40 border-red-900/50 text-red-400";
+      case "error":
+        return "bg-red-950/40 border-red-900/50 text-red-400";
+      case "warning":
+        return "bg-amber-950/40 border-amber-900/50 text-amber-400";
+      case "info":
+        return "bg-blue-950/40 border-blue-900/50 text-blue-400";
+      default:
+        return "bg-slate-950/40 border-slate-900/50 text-slate-400";
+    }
+  };
+
+  return (
+    <div className="bg-slate-900 border border-slate-800 rounded-xl p-6 shadow-xl max-w-3xl mx-auto my-6 text-slate-100">
+      <div className="flex items-start justify-between mb-4">
+        <div>
+          <span className="text-xs font-bold text-violet-400 uppercase tracking-wider">
+            Category: {report.error_category}
+          </span>
+          <h3 className="text-xl font-bold text-slate-100 flex items-center gap-2 mt-1">
+            {report.error_name}
+            <span className="text-sm font-mono text-slate-500 bg-slate-950 px-2 py-0.5 rounded border border-slate-800">
+              Code {report.error_code}
+            </span>
+          </h3>
+        </div>
+        <span className={`text-xs px-2.5 py-1 rounded border font-medium ${getSeverityStyles(report.severity)}`}>
+          {report.severity.toUpperCase()}
+        </span>
+      </div>
+
+      <div className="bg-slate-950 rounded-lg p-4 border border-slate-800 mb-6">
+        <h4 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-1">
+          Summary
+        </h4>
+        <p className="text-slate-300 text-sm">{report.summary}</p>
+      </div>
+
+      <div className="mb-6">
+        <h4 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-1">
+          Detailed Explanation
+        </h4>
+        <p className="text-slate-400 text-sm leading-relaxed whitespace-pre-line">
+          {report.detailed_explanation}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6 border-t border-slate-800 pt-6">
+        <div>
+          <h4 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-3">
+            Common Causes
+          </h4>
+          {report.root_causes && report.root_causes.length > 0 ? (
+            <ul className="space-y-3">
+              {report.root_causes.map((cause, i) => (
+                <li key={i} className="text-sm text-slate-300 flex items-start gap-2">
+                  <span className="text-red-400 mt-1">•</span>
+                  <div>
+                    <p>{cause.description}</p>
+                    <span className="text-[10px] text-slate-500 uppercase tracking-wider font-mono">
+                      Likelihood: {cause.likelihood}
+                    </span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-slate-500 italic">No common causes documented.</p>
+          )}
+        </div>
+
+        <div>
+          <h4 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-3">
+            Suggested Fixes
+          </h4>
+          {report.suggested_fixes && report.suggested_fixes.length > 0 ? (
+            <ul className="space-y-3">
+              {report.suggested_fixes.map((fix, i) => (
+                <li key={i} className="text-sm text-slate-300 flex items-start gap-2">
+                  <span className="text-emerald-400 mt-1">✓</span>
+                  <div>
+                    <p>{fix.description}</p>
+                    <div className="flex gap-2 mt-1">
+                      <span className="text-[10px] text-slate-500 uppercase tracking-wider font-mono">
+                        Difficulty: {fix.difficulty}
+                      </span>
+                      {fix.requires_upgrade && (
+                        <span className="text-[10px] text-amber-500 uppercase tracking-wider font-mono">
+                          Requires Upgrade
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-slate-500 italic">No suggested fixes documented.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/crates/core/src/decode/host_error.rs
+++ b/crates/core/src/decode/host_error.rs
@@ -105,9 +105,12 @@ impl HostError {
                 }
             }
             },
-            Self::Contract { code } => match code {
-               0 => "Contract error: the contract's own logic rejected this call — run with --resolve to map the code to its name.".to_string(),
-                _ => format!("Contract error (code {code}): the contract returned a non-zero error code — run with --resolve to identify it."),
+            Self::Contract { code } => {
+                if let Some(detail) = crate::decode::mappings::contract::lookup(*code) {
+                    detail.summary.to_string()
+                } else {
+                    format!("Contract error (code {code}): the contract returned a non-zero error code — run with --resolve to identify it.")
+                }
             },
             Self::Wasm { code } => {
                 if let Some(detail) = crate::decode::mappings::wasm::lookup(*code) {
@@ -342,6 +345,14 @@ mod tests {
         assert_eq!(
             HostError::Contract { code: 0 }.summary(),
             "Contract error: the contract's own logic rejected this call — run with --resolve to map the code to its name."
+        );
+        assert_eq!(
+            HostError::Contract { code: 1 }.summary(),
+            "An internal protocol implementation error occurred (e.g. invalid ledger state)."
+        );
+        assert_eq!(
+            HostError::Contract { code: 2 }.summary(),
+            "The operation is not supported (e.g. calling clawback on an asset without clawback enabled)."
         );
         assert_eq!(
             HostError::Wasm { code: 0 }.summary(),

--- a/crates/core/src/decode/mappings/contract.rs
+++ b/crates/core/src/decode/mappings/contract.rs
@@ -1,0 +1,65 @@
+use crate::types::report::Severity;
+
+/// A developer-friendly description of a standard `HostError::Contract` error code.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContractErrorDetail {
+    pub code: u32,
+    pub name: &'static str,
+    /// Short explanation of the failure.
+    pub summary: &'static str,
+    pub severity: Severity,
+}
+
+pub const CONTRACT_ERROR_DETAILS: &[ContractErrorDetail] = &[
+    ContractErrorDetail {
+        code: 0,
+        name: "ContractError",
+        summary: "Contract error: the contract's own logic rejected this call — run with --resolve to map the code to its name.",
+        severity: Severity::Error,
+    },
+    ContractErrorDetail {
+        code: 1,
+        name: "InternalError",
+        summary: "An internal protocol implementation error occurred (e.g. invalid ledger state).",
+        severity: Severity::Error,
+    },
+    ContractErrorDetail {
+        code: 2,
+        name: "OperationNotSupportedError",
+        summary: "The operation is not supported (e.g. calling clawback on an asset without clawback enabled).",
+        severity: Severity::Error,
+    },
+    ContractErrorDetail {
+        code: 3,
+        name: "AlreadyInitializedError",
+        summary: "The contract instance has already been initialized and cannot be re-initialized.",
+        severity: Severity::Error,
+    },
+    ContractErrorDetail {
+        code: 6,
+        name: "AccountMissingError",
+        summary: "An account involved in the transaction does not exist on the network.",
+        severity: Severity::Error,
+    },
+];
+
+pub fn lookup(code: u32) -> Option<&'static ContractErrorDetail> {
+    CONTRACT_ERROR_DETAILS.iter().find(|detail| detail.code == code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookup_returns_contract_error_detail() {
+        let detail = lookup(0).expect("contract error detail");
+        assert_eq!(detail.name, "ContractError");
+    }
+
+    #[test]
+    fn table_covers_known_contract_codes() {
+        assert_eq!(CONTRACT_ERROR_DETAILS.len(), 5);
+        assert!(lookup(99).is_none());
+    }
+}

--- a/crates/core/src/decode/mappings/mod.rs
+++ b/crates/core/src/decode/mappings/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod budget;
 pub mod context;
+pub mod contract;
 pub mod crypto;
 pub mod object;
 pub mod storage;
@@ -12,3 +13,4 @@ mod severity_tests;
 
 #[cfg(test)]
 mod crypto_tests;
+

--- a/crates/core/src/decode/mappings/severity_tests.rs
+++ b/crates/core/src/decode/mappings/severity_tests.rs
@@ -277,6 +277,17 @@ mod tests {
                 entry.code,
                 entry.severity
             );
+    #[test]
+    fn all_contract_entries_have_valid_severity() {
+        use crate::decode::mappings::contract::CONTRACT_ERROR_DETAILS;
+
+        for entry in CONTRACT_ERROR_DETAILS {
+            assert!(
+                matches!(entry.severity, Severity::Fatal | Severity::Error | Severity::Warning | Severity::Info),
+                "Unexpected severity for contract code {}: {:?}",
+                entry.code,
+                entry.severity
+            );
         }
     }
 }

--- a/crates/core/src/taxonomy/data/contract.toml
+++ b/crates/core/src/taxonomy/data/contract.toml
@@ -13,7 +13,7 @@ code = 0
 name = "ContractError"
 severity = "Error"
 since_protocol = 20
-summary = "The contract returned an error via its defined error enum."
+summary = "Contract error: the contract's own logic rejected this call — run with --resolve to map the code to its name."
 detailed_explanation = """
 Unlike host errors, contract errors are defined by the contract author. Each contract can \
 define an error enum with numeric codes and descriptive names. When a contract panics or \
@@ -46,4 +46,106 @@ difficulty = "medium"
 requires_upgrade = false
 
 related_errors = ["host.auth.not_authorized"]
+source_file = "soroban-env-host/src/host.rs"
+
+
+[[errors]]
+id = "host.contract.internal_error"
+category = "contract"
+code = 1
+name = "InternalError"
+severity = "Error"
+since_protocol = 20
+summary = "An internal protocol implementation error occurred (e.g. invalid ledger state)."
+detailed_explanation = """
+The contract encountered an internal error during execution, indicating a protocol \
+implementation issue or invalid ledger state.
+"""
+
+[[errors.common_causes]]
+description = "Internal validation or state consistency checks failed in the contract"
+likelihood = "high"
+
+[[errors.suggested_fixes]]
+description = "Check the diagnostic logs to see if there are internal contract assertion failures"
+difficulty = "medium"
+requires_upgrade = false
+
+related_errors = []
+source_file = "soroban-env-host/src/host.rs"
+
+
+[[errors]]
+id = "host.contract.operation_not_supported"
+category = "contract"
+code = 2
+name = "OperationNotSupportedError"
+severity = "Error"
+since_protocol = 20
+summary = "The operation is not supported (e.g. calling clawback on an asset without clawback enabled)."
+detailed_explanation = """
+The contract attempted an operation that is unsupported by the contract configuration or type \
+(e.g., performing a clawback on an asset when clawback is disabled).
+"""
+
+[[errors.common_causes]]
+description = "Invoking clawback on a non-clawbackable asset"
+likelihood = "high"
+
+[[errors.suggested_fixes]]
+description = "Check the asset flags and ensure the operation is allowed for the target asset"
+difficulty = "easy"
+requires_upgrade = false
+
+related_errors = []
+source_file = "soroban-env-host/src/host.rs"
+
+
+[[errors]]
+id = "host.contract.already_initialized"
+category = "contract"
+code = 3
+name = "AlreadyInitializedError"
+severity = "Error"
+since_protocol = 20
+summary = "The contract instance has already been initialized and cannot be re-initialized."
+detailed_explanation = """
+The contract instance was initialized twice. Soroban contracts typically only allow initialization once.
+"""
+
+[[errors.common_causes]]
+description = "Calling the initialize function on an already initialized contract instance"
+likelihood = "high"
+
+[[errors.suggested_fixes]]
+description = "Ensure that initialization is only called once per contract deployment"
+difficulty = "easy"
+requires_upgrade = false
+
+related_errors = []
+source_file = "soroban-env-host/src/host.rs"
+
+
+[[errors]]
+id = "host.contract.account_missing"
+category = "contract"
+code = 6
+name = "AccountMissingError"
+severity = "Error"
+since_protocol = 20
+summary = "An account involved in the transaction does not exist on the network."
+detailed_explanation = """
+The operation required a specific account to exist on the network, but the account could not be found.
+"""
+
+[[errors.common_causes]]
+description = "Providing an invalid account address or an account that has not been created/funded"
+likelihood = "high"
+
+[[errors.suggested_fixes]]
+description = "Verify that the addresses provided exist and are active on the target network"
+difficulty = "easy"
+requires_upgrade = false
+
+related_errors = []
 source_file = "soroban-env-host/src/host.rs"

--- a/crates/core/src/taxonomy/loader.rs
+++ b/crates/core/src/taxonomy/loader.rs
@@ -230,6 +230,13 @@ mod tests {
                     .map(|detail| (detail.code, detail.name))
                     .collect::<Vec<_>>(),
             ),
+            (
+                ErrorCategory::Contract,
+                crate::decode::mappings::contract::CONTRACT_ERROR_DETAILS
+                    .iter()
+                    .map(|detail| (detail.code, detail.name))
+                    .collect::<Vec<_>>(),
+            ),
         ];
 
         for (category, details) in expected_codes {


### PR DESCRIPTION
closes #265

# PR Description
Mapped standard `HostError::Contract` error codes to human-readable summaries and detailed explanations, and implemented a lookup and format reference mechanism in the web UI.

### Key Changes
1. **Core Mapping Module (`contract.rs`)**:
   - Created [contract.rs](https://github.com/Toolbox-Lab/Prism/tree/main/crates/core/src/decode/mappings/contract.rs) to map standard contract-level errors (0, 1, 2, 3, and 6) to their friendly error summaries, names, and severities.
   - Exposed the module in [mod.rs](https://github.com/Toolbox-Lab/Prism/tree/main/crates/core/src/decode/mappings/mod.rs).

2. **Core HostError Update**:
   - Updated `HostError::summary()` in [host_error.rs](https://github.com/Toolbox-Lab/Prism/tree/main/crates/core/src/decode/host_error.rs) to utilize the new lookup mechanism and added test coverage.

3. **Taxonomy & Schema Updates**:
   - Registered these error definitions inside [contract.toml](https://github.com/Toolbox-Lab/Prism/tree/main/crates/core/src/taxonomy/data/contract.toml) for system-wide taxonomy database resolution.
   - Updated [loader.rs](https://github.com/Toolbox-Lab/Prism/tree/main/crates/core/src/taxonomy/loader.rs) and [severity_tests.rs](https://github.com/Toolbox-Lab/Prism/tree/main/crates/core/src/decode/mappings/severity_tests.rs) with verification tests.

4. **UI Improvements**:
   - Implemented an interactive lookup tool component `ContractErrorView` in [ContractErrorView.tsx](https://github.com/Toolbox-Lab/Prism/tree/main/apps/web/src/components/decode/ContractErrorView.tsx) to query contract error codes.
   - Built a mock client-side decoding dashboard in [DecodeForm.tsx](https://github.com/Toolbox-Lab/Prism/tree/main/apps/web/src/components/decode/DecodeForm.tsx) and [ErrorCard.tsx](https://github.com/Toolbox-Lab/Prism/tree/main/apps/web/src/components/decode/ErrorCard.tsx) to map these codes in the UI.
   - Structured the page interface with tabbed layout in [page.tsx](https://github.com/Toolbox-Lab/Prism/tree/main/apps/web/src/app/decode/page.tsx).
