### PR TITLE
feat: distinguish Ed25519 and Smart Wallet authorization types

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - **Resource Profiling**: Identifies budget hotspots and expensive host function calls.
 - **Time-Travel Debugging**: Supports breakpoints, step-through execution, and "what-if" re-simulation.
 - **Multi-Interface Support**: Available via Rust CLI, VS Code Extension, and a Web Application.
+- **Authorization Type Detection**: Distinguishes Ed25519 account signatures from Smart Wallet (contract) authorizations and surfaces the relevant address or contract ID.
 
 ## Architecture
 
@@ -94,6 +95,48 @@ Profile contract execution to identify expensive storage reads or CPU-heavy host
 ### Regression Testing
 
 Export failed transactions as standalone test cases to ensure bugs are permanently resolved.
+
+## Authorization Type Detection
+
+Prism automatically identifies the kind of authorization used in each Soroban transaction and includes this information in every diagnostic report.
+
+### Supported Types
+
+| Type | Address Prefix | Description |
+|------|----------------|-------------|
+| **Ed25519** | `G...` | Classic Stellar account signing with its ed25519 key pair. |
+| **Smart Wallet** | `C...` | Deployed contract implementing custom signature verification (e.g., multi-sig, passkeys). |
+
+### Detection Logic
+
+Detection is based on the `ScAddress` variant inside each `SorobanAddressCredentials` entry:
+
+- `ScAddress::Account(...)` → **Ed25519** — a standard Stellar account.
+- `ScAddress::Contract(...)` → **Smart Wallet** — a deployed contract acting as an authorizer.
+
+`SourceAccount` credentials (where the transaction's own source account implicitly authorizes the entry) are not typed because they carry no separate address.
+
+### Report Fields
+
+Each decoded `DiagnosticReport` includes an `auth_entries` array with one entry per authorization found in the transaction:
+
+```json
+{
+  "auth_entries": [
+    {
+      "auth_type": "Ed25519",
+      "address": "GABC...XYZ"
+    },
+    {
+      "auth_type": "Smart Wallet",
+      "address": "CABC...XYZ",
+      "contract_id": "CABC...XYZ"
+    }
+  ]
+}
+```
+
+The existing `auth_signatures` field (hex-encoded ed25519 signature bytes) is preserved unchanged for backward compatibility.
 
 ## Contributing
 

--- a/crates/cli/src/output/renderers.rs
+++ b/crates/cli/src/output/renderers.rs
@@ -541,6 +541,11 @@ mod tests {
             }),
             transaction_context: None,
             related_errors: Vec::new(),
+            cross_contract_attribution: None,
+            auth_signatures: Vec::new(),
+            auth_entries: Vec::new(),
+            failing_contract_id: None,
+            learn_more: "https://developers.stellar.org/docs/learn/smart-contracts/errors".to_string(),
         }
     }
 

--- a/crates/core/src/decode/auth.rs
+++ b/crates/core/src/decode/auth.rs
@@ -17,6 +17,29 @@ use stellar_xdr::curr::{
     SorobanCredentials, Uint256,
 };
 
+/// The type of authorization credential used in a Soroban auth entry.
+///
+/// - `Ed25519`: a classic Stellar account (`G...` strkey) signing with its ed25519 key.
+/// - `SmartWallet`: a deployed contract (`C...` strkey) that implements custom
+///   signature verification logic (e.g., multi-sig, passkeys).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthorizationType {
+    /// Standard Ed25519 account authorization (G... address).
+    Ed25519,
+    /// Smart Wallet contract authorization (C... address).
+    SmartWallet,
+}
+
+impl std::fmt::Display for AuthorizationType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AuthorizationType::Ed25519 => write!(f, "Ed25519"),
+            AuthorizationType::SmartWallet => write!(f, "Smart Wallet"),
+        }
+    }
+}
+
 /// The credential that authorizes an [`AuthChain`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "kind")]
@@ -33,6 +56,12 @@ pub enum AuthCredential {
 pub struct AddressCredential {
     /// The authorizing address as a strkey (`G...` account or `C...` contract).
     pub address: String,
+    /// Whether this credential uses Ed25519 (G... account) or Smart Wallet (C... contract).
+    pub auth_type: AuthorizationType,
+    /// For Smart Wallet credentials, the contract ID in strkey form (`C...`).
+    /// `None` for Ed25519 accounts.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub contract_id: Option<String>,
     /// Replay-protection nonce chosen by the signer.
     pub nonce: i64,
     /// Ledger sequence at which this signature stops being valid.
@@ -111,8 +140,15 @@ fn parse_credential(credentials: &SorobanCredentials) -> AuthCredential {
 }
 
 fn parse_address_credential(creds: &SorobanAddressCredentials) -> AddressCredential {
+    let address = scaddress_to_strkey(&creds.address);
+    let (auth_type, contract_id) = match &creds.address {
+        ScAddress::Account(_) => (AuthorizationType::Ed25519, None),
+        ScAddress::Contract(_) => (AuthorizationType::SmartWallet, Some(address.clone())),
+    };
     AddressCredential {
-        address: scaddress_to_strkey(&creds.address),
+        address,
+        auth_type,
+        contract_id,
         nonce: creds.nonce,
         signature_expiration_ledger: creds.signature_expiration_ledger,
         signed: creds.signature != ScVal::Void,
@@ -303,6 +339,95 @@ mod tests {
             }
             other => panic!("expected address credential, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn ed25519_account_credential_has_correct_auth_type() {
+        let entry = SorobanAuthorizationEntry {
+            credentials: SorobanCredentials::Address(SorobanAddressCredentials {
+                address: account_address(3),
+                nonce: 1,
+                signature_expiration_ledger: 100,
+                signature: ScVal::Void,
+            }),
+            root_invocation: invocation(
+                contract_fn(contract_address(9), "transfer", vec![]),
+                empty_subs(),
+            ),
+        };
+
+        let chain = AuthChain::from_entry(&entry);
+        match chain.credential {
+            AuthCredential::Address(creds) => {
+                assert_eq!(creds.auth_type, AuthorizationType::Ed25519);
+                assert!(creds.address.starts_with('G'));
+                assert!(creds.contract_id.is_none(), "Ed25519 should have no contract_id");
+                assert_eq!(creds.auth_type.to_string(), "Ed25519");
+            }
+            other => panic!("expected address credential, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn smart_wallet_contract_credential_has_correct_auth_type() {
+        let entry = SorobanAuthorizationEntry {
+            credentials: SorobanCredentials::Address(SorobanAddressCredentials {
+                address: contract_address(5),
+                nonce: 99,
+                signature_expiration_ledger: 200,
+                signature: ScVal::Void,
+            }),
+            root_invocation: invocation(
+                contract_fn(contract_address(8), "invoke", vec![]),
+                empty_subs(),
+            ),
+        };
+
+        let chain = AuthChain::from_entry(&entry);
+        match chain.credential {
+            AuthCredential::Address(creds) => {
+                assert_eq!(creds.auth_type, AuthorizationType::SmartWallet);
+                assert!(creds.address.starts_with('C'));
+                // contract_id must equal address for smart wallet entries
+                let contract_id = creds.contract_id.as_deref().expect("smart wallet must have contract_id");
+                assert_eq!(contract_id, creds.address);
+                assert!(contract_id.starts_with('C'));
+                assert_eq!(creds.auth_type.to_string(), "Smart Wallet");
+            }
+            other => panic!("expected address credential, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn smart_wallet_contract_id_matches_address() {
+        // Verify contract_id is exactly equal to address for a contract credential.
+        let seed = 42u8;
+        let addr = contract_address(seed);
+        let entry = SorobanAuthorizationEntry {
+            credentials: SorobanCredentials::Address(SorobanAddressCredentials {
+                address: addr.clone(),
+                nonce: 0,
+                signature_expiration_ledger: 0,
+                signature: ScVal::Void,
+            }),
+            root_invocation: invocation(
+                contract_fn(contract_address(1), "fn", vec![]),
+                empty_subs(),
+            ),
+        };
+
+        let chain = AuthChain::from_entry(&entry);
+        if let AuthCredential::Address(creds) = chain.credential {
+            assert_eq!(creds.contract_id.as_deref(), Some(creds.address.as_str()));
+        } else {
+            panic!("expected address credential");
+        }
+    }
+
+    #[test]
+    fn authorization_type_display_labels() {
+        assert_eq!(AuthorizationType::Ed25519.to_string(), "Ed25519");
+        assert_eq!(AuthorizationType::SmartWallet.to_string(), "Smart Wallet");
     }
 
     #[test]

--- a/crates/core/src/decode/context.rs
+++ b/crates/core/src/decode/context.rs
@@ -1,8 +1,9 @@
 
 
+use crate::decode::auth::{AuthChain, AuthCredential, AuthorizationType};
 use crate::decode::auth_signature::decode_auth_entry_signatures;
 use crate::error::PrismResult;
-use crate::types::report::{DiagnosticReport, FeeBreakdown, ResourceSummary, TransactionContext};
+use crate::types::report::{AuthEntryInfo, DiagnosticReport, FeeBreakdown, ResourceSummary, TransactionContext};
 use crate::xdr::codec::XdrCodec;
 use stellar_xdr::curr::{
     FeeBumpTransactionInnerTx, LedgerEntryChange, Transaction, TransactionEnvelope, TransactionExt,
@@ -35,6 +36,9 @@ pub fn enrich_report(
 
     // Decode ed25519 signatures from auth entries embedded in the transaction envelope.
     report.auth_signatures = extract_auth_signatures(tx_data);
+
+    // Build typed auth entry summaries (Ed25519 vs Smart Wallet).
+    report.auth_entries = extract_auth_entries(tx_data);
 
     Ok(())
 }
@@ -266,6 +270,42 @@ fn extract_auth_signatures(tx_data: &serde_json::Value) -> Vec<String> {
     signatures
 }
 
+/// Build typed summaries for each auth entry found in the transaction.
+///
+/// For each entry, an [`AuthEntryInfo`] is produced that labels it as either
+/// Ed25519 or Smart Wallet and surfaces the relevant address / contract ID.
+/// Entries that cannot be decoded are silently skipped to remain non-breaking.
+fn extract_auth_entries(tx_data: &serde_json::Value) -> Vec<AuthEntryInfo> {
+    let mut entries = Vec::new();
+
+    if let Some(auth_array) = tx_data.get("auth").and_then(|a| a.as_array()) {
+        for entry in auth_array {
+            if let Some(xdr_b64) = entry.as_str() {
+                if let Ok(chain) = AuthChain::from_xdr_base64(xdr_b64) {
+                    if let Some(info) = auth_entry_info_from_chain(&chain) {
+                        entries.push(info);
+                    }
+                }
+            }
+        }
+    }
+
+    entries
+}
+
+/// Convert an [`AuthChain`] credential into an [`AuthEntryInfo`] label.
+/// Returns `None` for `SourceAccount` credentials, which carry no address info.
+fn auth_entry_info_from_chain(chain: &AuthChain) -> Option<AuthEntryInfo> {
+    match &chain.credential {
+        AuthCredential::SourceAccount => None,
+        AuthCredential::Address(cred) => Some(AuthEntryInfo {
+            auth_type: cred.auth_type.to_string(),
+            address: cred.address.clone(),
+            contract_id: cred.contract_id.clone(),
+        }),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -371,5 +411,121 @@ mod tests {
         assert_eq!(breakdown.inclusion_fee, 100); // 450 - 350
         assert_eq!(breakdown.refundable_fee, 250); // 200 + 50
         assert_eq!(breakdown.non_refundable_resource_fee, 100);
+    }
+
+    // ── auth_entries extraction tests ──────────────────────────────────────────
+
+    /// Helper: build an auth entry XDR base64 for an account (Ed25519) credential.
+    fn ed25519_auth_entry_b64(nonce: i64) -> String {
+        use stellar_xdr::curr::{
+            AccountId, Hash, InvokeContractArgs, PublicKey, ScAddress, ScSymbol, ScVal,
+            SorobanAddressCredentials, SorobanAuthorizationEntry, SorobanAuthorizedFunction,
+            SorobanAuthorizedInvocation, SorobanCredentials, Uint256,
+        };
+        let entry = SorobanAuthorizationEntry {
+            credentials: SorobanCredentials::Address(SorobanAddressCredentials {
+                address: ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
+                    [3u8; 32],
+                )))),
+                nonce,
+                signature_expiration_ledger: 100,
+                signature: ScVal::Void,
+            }),
+            root_invocation: SorobanAuthorizedInvocation {
+                function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
+                    contract_address: ScAddress::Contract(Hash([9u8; 32])),
+                    function_name: ScSymbol("transfer".try_into().unwrap()),
+                    args: vec![].try_into().unwrap(),
+                }),
+                sub_invocations: vec![].try_into().unwrap(),
+            },
+        };
+        XdrCodec::to_xdr_base64(&entry).expect("encode")
+    }
+
+    /// Helper: build an auth entry XDR base64 for a contract (Smart Wallet) credential.
+    fn smart_wallet_auth_entry_b64(nonce: i64) -> String {
+        use stellar_xdr::curr::{
+            Hash, InvokeContractArgs, ScAddress, ScSymbol, ScVal, SorobanAddressCredentials,
+            SorobanAuthorizationEntry, SorobanAuthorizedFunction, SorobanAuthorizedInvocation,
+            SorobanCredentials,
+        };
+        let entry = SorobanAuthorizationEntry {
+            credentials: SorobanCredentials::Address(SorobanAddressCredentials {
+                address: ScAddress::Contract(Hash([5u8; 32])),
+                nonce,
+                signature_expiration_ledger: 200,
+                signature: ScVal::Void,
+            }),
+            root_invocation: SorobanAuthorizedInvocation {
+                function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
+                    contract_address: ScAddress::Contract(Hash([8u8; 32])),
+                    function_name: ScSymbol("invoke".try_into().unwrap()),
+                    args: vec![].try_into().unwrap(),
+                }),
+                sub_invocations: vec![].try_into().unwrap(),
+            },
+        };
+        XdrCodec::to_xdr_base64(&entry).expect("encode")
+    }
+
+    #[test]
+    fn extract_auth_entries_detects_ed25519() {
+        let b64 = ed25519_auth_entry_b64(42);
+        let tx_data = serde_json::json!({ "auth": [b64] });
+        let entries = extract_auth_entries(&tx_data);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].auth_type, "Ed25519");
+        assert!(entries[0].address.starts_with('G'));
+        assert!(entries[0].contract_id.is_none());
+    }
+
+    #[test]
+    fn extract_auth_entries_detects_smart_wallet() {
+        let b64 = smart_wallet_auth_entry_b64(99);
+        let tx_data = serde_json::json!({ "auth": [b64] });
+        let entries = extract_auth_entries(&tx_data);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].auth_type, "Smart Wallet");
+        assert!(entries[0].address.starts_with('C'));
+        let contract_id = entries[0].contract_id.as_deref().expect("smart wallet must have contract_id");
+        assert_eq!(contract_id, entries[0].address);
+    }
+
+    #[test]
+    fn extract_auth_entries_handles_multiple_entries() {
+        let b64_ed = ed25519_auth_entry_b64(1);
+        let b64_sw = smart_wallet_auth_entry_b64(2);
+        let tx_data = serde_json::json!({ "auth": [b64_ed, b64_sw] });
+        let entries = extract_auth_entries(&tx_data);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].auth_type, "Ed25519");
+        assert_eq!(entries[1].auth_type, "Smart Wallet");
+    }
+
+    #[test]
+    fn extract_auth_entries_skips_invalid_payloads() {
+        let tx_data = serde_json::json!({ "auth": ["!!!not-valid-xdr!!!"] });
+        let entries = extract_auth_entries(&tx_data);
+        // Invalid entries are silently skipped; no panic.
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn extract_auth_entries_empty_when_no_auth_field() {
+        let tx_data = serde_json::json!({ "hash": "abc123" });
+        let entries = extract_auth_entries(&tx_data);
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn existing_ed25519_decoding_unchanged() {
+        // Existing auth_signatures behavior must be preserved for Ed25519 entries.
+        let b64 = ed25519_auth_entry_b64(7);
+        let tx_data = serde_json::json!({ "auth": [b64] });
+        // extract_auth_signatures should still return an empty vec
+        // because the entry has ScVal::Void (no signature bytes).
+        let sigs = extract_auth_signatures(&tx_data);
+        assert!(sigs.is_empty(), "no signature bytes in void-signed entry");
     }
 }

--- a/crates/core/src/decode/mod.rs
+++ b/crates/core/src/decode/mod.rs
@@ -5,7 +5,6 @@ pub mod auth_signature;
 pub mod decode_context;
 pub mod contract_error;
 pub mod cross_contract;
-pub mod decode_context;
 pub mod diagnostic;
 pub mod host_error;
 pub mod mappings;
@@ -14,6 +13,7 @@ pub mod walker;
 
 pub use auth::{
     AddressCredential, AuthChain, AuthCredential, AuthFunctionKind, AuthInvocation,
+    AuthorizationType,
 };
 pub use auth_address_nonce::AddressWithNonce;
 pub use walker::{

--- a/crates/core/src/decode/report.rs
+++ b/crates/core/src/decode/report.rs
@@ -44,6 +44,8 @@ pub fn build_report(error: &ClassifiedError) -> PrismResult<DiagnosticReport> {
             related_errors: entry.related_errors.clone(),
             cross_contract_attribution: None,
             auth_signatures: Vec::new(),
+            auth_entries: Vec::new(),
+            failing_contract_id: None,
             learn_more: "https://developers.stellar.org/docs/learn/smart-contracts/errors".to_string(),
         };
 

--- a/crates/core/src/types/report.rs
+++ b/crates/core/src/types/report.rs
@@ -2,6 +2,19 @@
 
 use serde::{Deserialize, Serialize};
 
+/// A summary of a decoded authorization entry, including its detected type.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuthEntryInfo {
+    /// Human-readable label: "Ed25519" or "Smart Wallet".
+    pub auth_type: String,
+    /// The authorizing address as a strkey (`G...` for Ed25519, `C...` for Smart Wallet).
+    pub address: String,
+    /// For Smart Wallet entries: the contract ID in strkey form (`C...`).
+    /// `None` for Ed25519 entries.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub contract_id: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum Severity {
@@ -136,6 +149,16 @@ pub struct DiagnosticReport {
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub auth_signatures: Vec<String>,
 
+    /// Typed summaries of each authorization entry found in the transaction,
+    /// labelled as Ed25519 or Smart Wallet with the relevant address/contract_id.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub auth_entries: Vec<AuthEntryInfo>,
+
+    /// The contract address most likely responsible for the failure, extracted
+    /// from diagnostic event traces.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub failing_contract_id: Option<String>,
+
     pub learn_more: String,
 }
 
@@ -156,6 +179,8 @@ impl DiagnosticReport {
             related_errors: Vec::new(),
             cross_contract_attribution: None,
             auth_signatures: Vec::new(),
+            auth_entries: Vec::new(),
+            failing_contract_id: None,
             learn_more: "https://developers.stellar.org/docs/learn/smart-contracts/errors".to_string(),  
        }
     }


### PR DESCRIPTION
### Summary

* Detect Ed25519 and Smart Wallet authorization types.
* Preserve existing Ed25519 decoding.
* Decode and display Smart Wallet Contract IDs.
* Add focused tests.
* Update documentation.

### Changes

- Added `AuthorizationType` enum (`Ed25519` | `SmartWallet`) with `Display` impl to `auth.rs`
- Added `auth_type` and `contract_id` fields to `AddressCredential`; detection based on `ScAddress` variant
- Added `AuthEntryInfo` struct and `auth_entries: Vec<AuthEntryInfo>` field to `DiagnosticReport`
- Wired `extract_auth_entries` into `context::enrich_report` alongside existing `auth_signatures`
- Fixed pre-existing compile error: added missing `failing_contract_id` field to `DiagnosticReport`
- Added 11 focused tests across `auth.rs` and `context.rs`
- Updated README with Authorization Type Detection section, detection logic, and example JSON output

### Validation

```bash
cargo fmt --all -- --check
cargo check
cargo test
```

All checks pass.

Closes #271