### PR TITLE
fix: implement resilient POST client for replay job submission

### DIFF
--- a/examples/api-clients/mock-replay-submitter/index.js
+++ b/examples/api-clients/mock-replay-submitter/index.js
@@ -1,1 +1,88 @@
-// Dummy implementation for Mock Replay Submitter
+#!/usr/bin/env node
+
+const API_URL = process.env.API_URL || 'http://localhost:3001';
+const REPLAY_ENDPOINT = `${API_URL}/api/replay`;
+
+/**
+ * Submits a transaction hash to the grat-server replay API and returns the
+ * job token used to track simulation progress.
+ *
+ * Resilient against:
+ * - Fastify 415 Unsupported Media Type (explicit Content-Type/Accept headers)
+ * - Network-level failures — DNS errors, connection refused, server downtime
+ *   (fetch rejections are caught here instead of propagating as unhandled
+ *   Promise rejections that would crash the process)
+ * - Non-2xx responses (4xx/5xx), surfaced as descriptive errors
+ * - Malformed or unexpected JSON response bodies
+ */
+async function submitReplayJob(txHash) {
+  let response;
+  try {
+    response = await fetch(REPLAY_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({ tx_hash: txHash }),
+    });
+  } catch (err) {
+    throw new Error(
+      `Could not reach grat-server at ${REPLAY_ENDPOINT}: ${err.message}. ` +
+        'Is the server running? (pnpm --filter grat-server dev)'
+    );
+  }
+
+  let payload;
+  try {
+    payload = await response.json();
+  } catch (err) {
+    throw new Error(
+      `Server returned a non-JSON response (HTTP ${response.status} ${response.statusText}): ${err.message}`
+    );
+  }
+
+  if (!response.ok) {
+    const detail = payload && (payload.error || payload.message);
+    throw new Error(
+      `Replay submission failed with HTTP ${response.status} ${response.statusText}` +
+        (detail ? `: ${detail}` : '')
+    );
+  }
+
+  if (!payload || !payload.jobId) {
+    throw new Error(
+      `Replay submission succeeded (HTTP ${response.status}) but the response did not include a "jobId": ${JSON.stringify(
+        payload
+      )}`
+    );
+  }
+
+  return payload.jobId;
+}
+
+async function main() {
+  const txHash = process.argv[2];
+
+  if (!txHash) {
+    console.error('Usage: node index.js <tx-hash>');
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`Submitting replay job for ${txHash} to ${REPLAY_ENDPOINT}...`);
+
+  try {
+    const jobId = await submitReplayJob(txHash);
+    console.log(`✓ Replay job accepted. jobId: ${jobId}`);
+  } catch (err) {
+    console.error(`✗ ${err.message}`);
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { submitReplayJob };


### PR DESCRIPTION
## Summary
- Implements the `examples/api-clients/mock-replay-submitter/index.js` script, previously a one-line stub, as a resilient HTTP client wrapper around native `fetch`.
- Sets `Content-Type: application/json` and `Accept: application/json` headers on the POST to `http://localhost:3001/api/replay` (overridable via `API_URL` env var, consistent with the sibling `websocket-client` example).
- Catches network-level failures (DNS errors, connection refused, server downtime) so they surface as a clear message instead of an unhandled Promise rejection that crashes the process.
- Checks `Response.ok` before trusting the body, safely parses `Response.json()`, and extracts `jobId`, throwing a descriptive error for non-2xx responses (including 500) or a response missing `jobId`.

## Test plan
Verified locally against `apps/server` (`pnpm --filter grat-server dev`):
- [x] Server down → clean "could not reach grat-server" message, exit code 1, no unhandled rejection.
- [x] No `tx-hash` argument → usage message, exit code 1.
- [x] Server up, proper headers sent → no 415 (confirmed the request negotiates correctly).
- [x] Simulated `500` response → descriptive `HTTP 500 ... : temporary test failure` error, exit code 1.
- [x] Simulated success with no `jobId` in body (current state of `POST /api/replay`, which only returns `{ status: "queued" }`) → descriptive "response did not include a jobId" error, exit code 1.

Note: `apps/server`'s `POST /api/replay` handler currently returns `{ status: "queued" }` with no `jobId` field at all (it's a scaffold/stub, out of scope for this issue per the "Files location" in #313). Once that route is implemented to actually return a `jobId`, this client will pick it up correctly with no changes needed — confirmed by testing against a temporarily-patched local route.

Fixes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)