### PR TITLE
fix: capture stderr output in CLI bridge 

### DIFF
--- a/extensions/vscode/src/cli/bridge.ts
+++ b/extensions/vscode/src/cli/bridge.ts
@@ -1,13 +1,23 @@
-import { execFile } from "child_process";
+import { execFile } from 'child_process';
 
 export function callGrat(args: string[]): Promise<unknown> {
   return new Promise((resolve, reject) => {
-    execFile("grat", [...args, "--output", "json"], (error, stdout) => {
-      if (error) return reject(error);
+    execFile('grat', [...args, '--output', 'json'], (error, stdout, stderr) => {
+      if (error) {
+        const stderrMsg = stderr ? stderr.trim() : '';
+        const message = stderrMsg
+          ? 'grat CLI error: ' + stderrMsg
+          : 'grat CLI failed: ' + (error.message || 'Unknown error');
+        return reject(new Error(message));
+      }
       try {
         resolve(JSON.parse(stdout));
       } catch {
-        reject(new Error("Failed to parse grat output"));
+        const stderrMsg = stderr ? stderr.trim() : '';
+        const message = stderrMsg
+          ? 'Failed to parse grat output: ' + stderrMsg
+          : 'Failed to parse grat output';
+        reject(new Error(message));
       }
     });
   });


### PR DESCRIPTION
Captures stderr from grat CLI child process and includes it in error messages.

- execFile callback now reads stderr parameter
- On execution error: includes stderr text in reject message
- On parse error: includes stderr text in reject message
- Developers now see exact CLI failure reason instead of generic message

Closes #301