### PR TITLE
feat(examples): flatten TOML error taxonomy into O(1) lookup dictionary

### DIFF
--- a/examples/core-integration/fetch-taxonomy/README.md
+++ b/examples/core-integration/fetch-taxonomy/README.md
@@ -4,6 +4,19 @@ This example script demonstrates how the React Web Application should dynamicall
 
 Currently, the React frontend hardcodes Soroban error numbers (Issue #4), which is unmaintainable. This script reads `crates/core/src/taxonomy/data/contract.toml`, parses it using the `@iarna/toml` library, and writes a normalized JSON dictionary.
 
+## Flattening
+
+The `@iarna/toml` parser returns an AST that mirrors the Rust codebase's nested namespaces (e.g. `[errors.contract.authentication]`), which is hostile to UI code that needs instant lookups. A recursive graph walker (`flattenTaxonomy`) collapses that tree into a single-level dictionary keyed by numeric error code, so the frontend can resolve any code in O(1) with zero recursive overhead:
+
+```json
+{
+  "0": { "code": 0, "name": "ContractError", "summary": "..." },
+  "6": { "code": 6, "name": "AccountMissingError", "summary": "..." }
+}
+```
+
+The walker uses `Object.entries()` to iterate structural grouping nodes, recurses until it reaches terminal leaf nodes (definition tables carrying `name`/description primitives and a resolvable code), and is fully defensive: unexpected shapes introduced upstream (a generic array or bare primitive where a definition table belongs, `null`, mixed arrays) are skipped with a discrete warning instead of crashing with a `TypeError`. Duplicate codes keep the first definition encountered and emit a warning.
+
 ## Installation
 
 ```bash
@@ -16,4 +29,10 @@ pnpm install
 ```bash
 npm start
 ```
-This will read the TOML file from the `crates/core` directory and output a JSON format to the console or write it to a `taxonomy.json` file.
+This will read the TOML file from the `crates/core` directory, flatten it, and write the resulting dictionary to `taxonomy.json`.
+
+## Running the Tests
+
+```bash
+npm test
+```

--- a/examples/core-integration/fetch-taxonomy/index.js
+++ b/examples/core-integration/fetch-taxonomy/index.js
@@ -71,7 +71,112 @@ function sanitizeAndNormalize(value, key = '') {
   return value;
 }
 
-async function buildTaxonomyJson({ inputPath, outputPath }) {
+const NUMERIC_KEY_PATTERN = /^-?\d+$/;
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function resolveErrorCode(node, key) {
+  const candidates = [node.code, node.error_code, key];
+
+  for (const candidate of candidates) {
+    if (candidate === undefined || candidate === null || candidate === '') {
+      continue;
+    }
+
+    const normalized = normalizeErrorCode(candidate);
+    if (typeof normalized === 'number') {
+      return normalized;
+    }
+
+    if (typeof normalized === 'string' && NUMERIC_KEY_PATTERN.test(normalized)) {
+      return normalized;
+    }
+  }
+
+  return null;
+}
+
+function isErrorDefinition(node, key) {
+  return isPlainObject(node) && typeof node.name === 'string' && resolveErrorCode(node, key) !== null;
+}
+
+function flattenTaxonomy(root, options = {}) {
+  const dictionary = {};
+  const warnings = [];
+
+  const warn = (path, message) => {
+    warnings.push({ path, message });
+    if (typeof options.onWarning === 'function') {
+      options.onWarning(`[flatten-taxonomy] ${path}: ${message}`);
+    }
+  };
+
+  const addDefinition = (node, key, path) => {
+    const code = resolveErrorCode(node, key);
+    const dictionaryKey = String(code);
+
+    if (Object.prototype.hasOwnProperty.call(dictionary, dictionaryKey)) {
+      warn(path, `duplicate error code ${dictionaryKey}; keeping the first definition encountered`);
+      return;
+    }
+
+    dictionary[dictionaryKey] = { ...node, code };
+  };
+
+  const visit = (node, key, path) => {
+    if (Array.isArray(node)) {
+      node.forEach((item, index) => {
+        const itemPath = `${path}[${index}]`;
+
+        if (isPlainObject(item) || Array.isArray(item)) {
+          visit(item, key, itemPath);
+        }
+        // Primitive array entries (e.g. related_errors string lists) are plain
+        // metadata attached to a definition — nothing to flatten, skip quietly.
+      });
+      return;
+    }
+
+    if (!isPlainObject(node)) {
+      return;
+    }
+
+    if (isErrorDefinition(node, key)) {
+      addDefinition(node, key, path);
+      return;
+    }
+
+    for (const [childKey, childValue] of Object.entries(node)) {
+      const childPath = path ? `${path}.${childKey}` : childKey;
+
+      if (NUMERIC_KEY_PATTERN.test(childKey) && !isPlainObject(childValue)) {
+        // A numeric key promises an error definition table. Anything else
+        // (an array, a bare string, …) is a schema deviation from upstream:
+        // skip it instead of letting a property access blow up downstream.
+        warn(childPath, `expected an error definition table but found ${describeShape(childValue)}; node skipped`);
+        continue;
+      }
+
+      if (isPlainObject(childValue) || Array.isArray(childValue)) {
+        visit(childValue, childKey, childPath);
+      }
+    }
+  };
+
+  visit(root, '', '');
+
+  return { dictionary, warnings };
+}
+
+function describeShape(value) {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'an array';
+  return `a ${typeof value}`;
+}
+
+async function buildTaxonomyJson({ inputPath, outputPath, onWarning }) {
   let input;
   try {
     input = await readFile(inputPath, 'utf8');
@@ -87,7 +192,8 @@ async function buildTaxonomyJson({ inputPath, outputPath }) {
   }
 
   const sanitized = sanitizeAndNormalize(parsed);
-  const serialized = JSON.stringify(sanitized, null, 2) + '\n';
+  const { dictionary, warnings } = flattenTaxonomy(sanitized, { onWarning });
+  const serialized = JSON.stringify(dictionary, null, 2) + '\n';
 
   try {
     await writeFile(outputPath, serialized, 'utf8');
@@ -99,7 +205,7 @@ async function buildTaxonomyJson({ inputPath, outputPath }) {
     );
   }
 
-  return serialized;
+  return { serialized, dictionary, warnings };
 }
 
 function formatReadError(error, inputPath) {
@@ -132,8 +238,13 @@ async function main() {
   const inputPath = path.join(workspaceRoot, 'crates', 'core', 'src', 'taxonomy', 'data', 'contract.toml');
   const outputPath = path.join(__dirname, 'taxonomy.json');
 
-  const serialized = await buildTaxonomyJson({ inputPath, outputPath });
-  console.log(`Wrote sanitized taxonomy JSON to ${path.relative(workspaceRoot, outputPath)}`);
+  const { serialized, dictionary } = await buildTaxonomyJson({
+    inputPath,
+    outputPath,
+    onWarning: (message) => console.warn(message),
+  });
+  const entryCount = Object.keys(dictionary).length;
+  console.log(`Wrote flattened taxonomy JSON (${entryCount} error codes) to ${path.relative(workspaceRoot, outputPath)}`);
   return serialized;
 }
 
@@ -148,6 +259,10 @@ module.exports = {
   sanitizeText,
   normalizeErrorCode,
   sanitizeAndNormalize,
+  isPlainObject,
+  isErrorDefinition,
+  resolveErrorCode,
+  flattenTaxonomy,
   buildTaxonomyJson,
   formatReadError,
 };

--- a/examples/core-integration/fetch-taxonomy/index.test.js
+++ b/examples/core-integration/fetch-taxonomy/index.test.js
@@ -1,6 +1,8 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { sanitizeText, normalizeErrorCode } = require('./index');
+const os = require('node:os');
+const path = require('node:path');
+const { sanitizeText, normalizeErrorCode, flattenTaxonomy, buildTaxonomyJson } = require('./index');
 
 test('sanitizeText trims and normalizes pesky whitespace', () => {
   const value = '  Contract error\r\nwith trailing spaces   \r\n';
@@ -11,4 +13,127 @@ test('normalizeErrorCode preserves unsafe integers without losing precision', ()
   assert.equal(normalizeErrorCode(42), 42);
   assert.equal(normalizeErrorCode('9007199254740993'), '9007199254740993');
   assert.equal(normalizeErrorCode(BigInt('9007199254740993')), '9007199254740993');
+});
+
+test('flattenTaxonomy flattens array-of-tables definitions keyed by their code field', () => {
+  const ast = {
+    category: { name: 'Contract', description: 'Errors raised by contract code.' },
+    errors: [
+      { code: 0, name: 'ContractError', summary: 'General contract error.' },
+      { code: 6, name: 'AccountMissingError', summary: 'Account does not exist.' },
+    ],
+  };
+
+  const { dictionary, warnings } = flattenTaxonomy(ast);
+
+  assert.deepEqual(Object.keys(dictionary).sort(), ['0', '6']);
+  assert.equal(dictionary['0'].name, 'ContractError');
+  assert.equal(dictionary['6'].summary, 'Account does not exist.');
+  assert.equal(warnings.length, 0);
+});
+
+test('flattenTaxonomy resolves definitions nested arbitrarily deep in namespace sections', () => {
+  const ast = {
+    errors: {
+      contract: {
+        authentication: {
+          1042: { name: 'InvalidSignature', description: 'The signature check failed.' },
+        },
+        storage: {
+          ledger: {
+            2077: { name: 'EntryExpired', description: 'The ledger entry has expired.' },
+          },
+        },
+      },
+    },
+  };
+
+  const { dictionary, warnings } = flattenTaxonomy(ast);
+
+  assert.equal(dictionary['1042'].name, 'InvalidSignature');
+  assert.equal(dictionary['1042'].code, 1042);
+  assert.equal(dictionary['2077'].description, 'The ledger entry has expired.');
+  assert.equal(warnings.length, 0);
+});
+
+test('flattenTaxonomy skips anomalous shapes instead of crashing', () => {
+  const ast = {
+    errors: {
+      contract: {
+        // Upstream regression: a generic array where a definition table belongs.
+        1042: ['not', 'a', 'table'],
+        // A bare primitive under a numeric key.
+        1043: 'just a string',
+        // Structural junk that must not blow up the walker.
+        weird: null,
+        deeper: {
+          1044: { name: 'StillWorks', description: 'Valid sibling of anomalous nodes.' },
+        },
+      },
+      mixed_array: [null, 'metadata', ['nested', 'primitives'], { code: 7, name: 'FromMixedArray' }],
+    },
+  };
+
+  const seen = [];
+  const { dictionary, warnings } = flattenTaxonomy(ast, { onWarning: (message) => seen.push(message) });
+
+  assert.deepEqual(Object.keys(dictionary).sort(), ['1044', '7']);
+  assert.equal(dictionary['1044'].name, 'StillWorks');
+  assert.equal(dictionary['7'].name, 'FromMixedArray');
+
+  assert.equal(warnings.length, 2);
+  assert.match(warnings[0].message, /expected an error definition table but found an array/);
+  assert.match(warnings[1].message, /expected an error definition table but found a string/);
+  assert.equal(seen.length, 2);
+});
+
+test('flattenTaxonomy keeps the first definition and warns on duplicate codes', () => {
+  const ast = {
+    errors: [
+      { code: 3, name: 'AlreadyInitializedError', summary: 'First definition wins.' },
+      { code: 3, name: 'ShadowedDuplicate', summary: 'Must not overwrite.' },
+    ],
+  };
+
+  const { dictionary, warnings } = flattenTaxonomy(ast);
+
+  assert.equal(dictionary['3'].name, 'AlreadyInitializedError');
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0].message, /duplicate error code 3/);
+});
+
+test('flattenTaxonomy does not mistake descriptive sub-tables for definitions', () => {
+  const ast = {
+    errors: [
+      {
+        code: 0,
+        name: 'ContractError',
+        common_causes: [{ description: 'Business logic failure', likelihood: 'high' }],
+        suggested_fixes: [{ description: 'Use the resolver', difficulty: 'easy' }],
+        related_errors: ['host.auth.not_authorized'],
+      },
+    ],
+  };
+
+  const { dictionary, warnings } = flattenTaxonomy(ast);
+
+  assert.deepEqual(Object.keys(dictionary), ['0']);
+  assert.equal(dictionary['0'].common_causes.length, 1);
+  assert.equal(warnings.length, 0);
+});
+
+test('buildTaxonomyJson produces a flat O(1) dictionary from the real contract.toml', async () => {
+  const inputPath = path.resolve(__dirname, '..', '..', '..', 'crates', 'core', 'src', 'taxonomy', 'data', 'contract.toml');
+  const outputPath = path.join(os.tmpdir(), `taxonomy-test-${process.pid}.json`);
+
+  const { dictionary, warnings } = await buildTaxonomyJson({ inputPath, outputPath });
+
+  assert.equal(warnings.length, 0);
+  assert.equal(dictionary['0'].name, 'ContractError');
+  assert.equal(dictionary['6'].name, 'AccountMissingError');
+
+  for (const definition of Object.values(dictionary)) {
+    assert.equal(typeof definition.name, 'string');
+    assert.equal(Array.isArray(definition), false);
+  }
 });

--- a/examples/core-integration/fetch-taxonomy/package.json
+++ b/examples/core-integration/fetch-taxonomy/package.json
@@ -4,7 +4,8 @@
   "description": "Example showing how to parse the core TOML error taxonomy into JSON.",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "node --test"
   },
   "dependencies": {
     "@iarna/toml": "^2.2.5"

--- a/examples/core-integration/fetch-taxonomy/taxonomy.json
+++ b/examples/core-integration/fetch-taxonomy/taxonomy.json
@@ -1,149 +1,142 @@
 {
-  "category": {
-    "name": "Contract",
-    "description": "Errors raised by contract code itself (not the host). These use numeric codes defined in the contract's error enum.",
-    "source_module": "soroban-env-host/src/host.rs"
+  "0": {
+    "id": "host.contract.error_general",
+    "category": "contract",
+    "code": 0,
+    "name": "ContractError",
+    "severity": "Error",
+    "since_protocol": 20,
+    "summary": "Contract error: the contract's own logic rejected this call — run with --resolve to map the code to its name.",
+    "detailed_explanation": "Unlike host errors, contract errors are defined by the contract author. Each contract can define an error enum with numeric codes and descriptive names. When a contract panics or returns an error value, the host wraps it as a ContractError with the numeric code.\n\nTo understand a contract error, you need the contract's specification (contractspecv0 metadata) which maps the numeric code to a human-readable name and optional documentation.",
+    "common_causes": [
+      {
+        "description": "Business logic assertion failure in the contract (e.g., insufficient balance, invalid state)",
+        "likelihood": "high"
+      },
+      {
+        "description": "Input validation failure — the contract rejected the provided arguments",
+        "likelihood": "high"
+      },
+      {
+        "description": "Access control check failed — the caller is not authorized for this operation",
+        "likelihood": "medium"
+      }
+    ],
+    "suggested_fixes": [
+      {
+        "description": "Use grat's contract error resolver to map the numeric code to the contract's error enum name",
+        "difficulty": "easy",
+        "requires_upgrade": false
+      },
+      {
+        "description": "Review the contract source code for the error enum definition to understand the specific failure",
+        "difficulty": "medium",
+        "requires_upgrade": false,
+        "related_errors": [
+          "host.auth.not_authorized"
+        ],
+        "source_file": "soroban-env-host/src/host.rs"
+      }
+    ]
   },
-  "errors": [
-    {
-      "id": "host.contract.error_general",
-      "category": "contract",
-      "code": 0,
-      "name": "ContractError",
-      "severity": "Error",
-      "since_protocol": 20,
-      "summary": "Contract error: the contract's own logic rejected this call — run with --resolve to map the code to its name.",
-      "detailed_explanation": "Unlike host errors, contract errors are defined by the contract author. Each contract can define an error enum with numeric codes and descriptive names. When a contract panics or returns an error value, the host wraps it as a ContractError with the numeric code.\n\nTo understand a contract error, you need the contract's specification (contractspecv0 metadata) which maps the numeric code to a human-readable name and optional documentation.",
-      "common_causes": [
-        {
-          "description": "Business logic assertion failure in the contract (e.g., insufficient balance, invalid state)",
-          "likelihood": "high"
-        },
-        {
-          "description": "Input validation failure — the contract rejected the provided arguments",
-          "likelihood": "high"
-        },
-        {
-          "description": "Access control check failed — the caller is not authorized for this operation",
-          "likelihood": "medium"
-        }
-      ],
-      "suggested_fixes": [
-        {
-          "description": "Use grat's contract error resolver to map the numeric code to the contract's error enum name",
-          "difficulty": "easy",
-          "requires_upgrade": false
-        },
-        {
-          "description": "Review the contract source code for the error enum definition to understand the specific failure",
-          "difficulty": "medium",
-          "requires_upgrade": false,
-          "related_errors": [
-            "host.auth.not_authorized"
-          ],
-          "source_file": "soroban-env-host/src/host.rs"
-        }
-      ]
-    },
-    {
-      "id": "host.contract.internal_error",
-      "category": "contract",
-      "code": 1,
-      "name": "InternalError",
-      "severity": "Error",
-      "since_protocol": 20,
-      "summary": "An internal protocol implementation error occurred (e.g. invalid ledger state).",
-      "detailed_explanation": "The contract encountered an internal error during execution, indicating a protocol implementation issue or invalid ledger state.",
-      "common_causes": [
-        {
-          "description": "Internal validation or state consistency checks failed in the contract",
-          "likelihood": "high"
-        }
-      ],
-      "suggested_fixes": [
-        {
-          "description": "Check the diagnostic logs to see if there are internal contract assertion failures",
-          "difficulty": "medium",
-          "requires_upgrade": false,
-          "related_errors": [],
-          "source_file": "soroban-env-host/src/host.rs"
-        }
-      ]
-    },
-    {
-      "id": "host.contract.operation_not_supported",
-      "category": "contract",
-      "code": 2,
-      "name": "OperationNotSupportedError",
-      "severity": "Error",
-      "since_protocol": 20,
-      "summary": "The operation is not supported (e.g. calling clawback on an asset without clawback enabled).",
-      "detailed_explanation": "The contract attempted an operation that is unsupported by the contract configuration or type (e.g., performing a clawback on an asset when clawback is disabled).",
-      "common_causes": [
-        {
-          "description": "Invoking clawback on a non-clawbackable asset",
-          "likelihood": "high"
-        }
-      ],
-      "suggested_fixes": [
-        {
-          "description": "Check the asset flags and ensure the operation is allowed for the target asset",
-          "difficulty": "easy",
-          "requires_upgrade": false,
-          "related_errors": [],
-          "source_file": "soroban-env-host/src/host.rs"
-        }
-      ]
-    },
-    {
-      "id": "host.contract.already_initialized",
-      "category": "contract",
-      "code": 3,
-      "name": "AlreadyInitializedError",
-      "severity": "Error",
-      "since_protocol": 20,
-      "summary": "The contract instance has already been initialized and cannot be re-initialized.",
-      "detailed_explanation": "The contract instance was initialized twice. Soroban contracts typically only allow initialization once.",
-      "common_causes": [
-        {
-          "description": "Calling the initialize function on an already initialized contract instance",
-          "likelihood": "high"
-        }
-      ],
-      "suggested_fixes": [
-        {
-          "description": "Ensure that initialization is only called once per contract deployment",
-          "difficulty": "easy",
-          "requires_upgrade": false,
-          "related_errors": [],
-          "source_file": "soroban-env-host/src/host.rs"
-        }
-      ]
-    },
-    {
-      "id": "host.contract.account_missing",
-      "category": "contract",
-      "code": 6,
-      "name": "AccountMissingError",
-      "severity": "Error",
-      "since_protocol": 20,
-      "summary": "An account involved in the transaction does not exist on the network.",
-      "detailed_explanation": "The operation required a specific account to exist on the network, but the account could not be found.",
-      "common_causes": [
-        {
-          "description": "Providing an invalid account address or an account that has not been created/funded",
-          "likelihood": "high"
-        }
-      ],
-      "suggested_fixes": [
-        {
-          "description": "Verify that the addresses provided exist and are active on the target network",
-          "difficulty": "easy",
-          "requires_upgrade": false,
-          "related_errors": [],
-          "source_file": "soroban-env-host/src/host.rs"
-        }
-      ]
-    }
-  ]
+  "1": {
+    "id": "host.contract.internal_error",
+    "category": "contract",
+    "code": 1,
+    "name": "InternalError",
+    "severity": "Error",
+    "since_protocol": 20,
+    "summary": "An internal protocol implementation error occurred (e.g. invalid ledger state).",
+    "detailed_explanation": "The contract encountered an internal error during execution, indicating a protocol implementation issue or invalid ledger state.",
+    "common_causes": [
+      {
+        "description": "Internal validation or state consistency checks failed in the contract",
+        "likelihood": "high"
+      }
+    ],
+    "suggested_fixes": [
+      {
+        "description": "Check the diagnostic logs to see if there are internal contract assertion failures",
+        "difficulty": "medium",
+        "requires_upgrade": false,
+        "related_errors": [],
+        "source_file": "soroban-env-host/src/host.rs"
+      }
+    ]
+  },
+  "2": {
+    "id": "host.contract.operation_not_supported",
+    "category": "contract",
+    "code": 2,
+    "name": "OperationNotSupportedError",
+    "severity": "Error",
+    "since_protocol": 20,
+    "summary": "The operation is not supported (e.g. calling clawback on an asset without clawback enabled).",
+    "detailed_explanation": "The contract attempted an operation that is unsupported by the contract configuration or type (e.g., performing a clawback on an asset when clawback is disabled).",
+    "common_causes": [
+      {
+        "description": "Invoking clawback on a non-clawbackable asset",
+        "likelihood": "high"
+      }
+    ],
+    "suggested_fixes": [
+      {
+        "description": "Check the asset flags and ensure the operation is allowed for the target asset",
+        "difficulty": "easy",
+        "requires_upgrade": false,
+        "related_errors": [],
+        "source_file": "soroban-env-host/src/host.rs"
+      }
+    ]
+  },
+  "3": {
+    "id": "host.contract.already_initialized",
+    "category": "contract",
+    "code": 3,
+    "name": "AlreadyInitializedError",
+    "severity": "Error",
+    "since_protocol": 20,
+    "summary": "The contract instance has already been initialized and cannot be re-initialized.",
+    "detailed_explanation": "The contract instance was initialized twice. Soroban contracts typically only allow initialization once.",
+    "common_causes": [
+      {
+        "description": "Calling the initialize function on an already initialized contract instance",
+        "likelihood": "high"
+      }
+    ],
+    "suggested_fixes": [
+      {
+        "description": "Ensure that initialization is only called once per contract deployment",
+        "difficulty": "easy",
+        "requires_upgrade": false,
+        "related_errors": [],
+        "source_file": "soroban-env-host/src/host.rs"
+      }
+    ]
+  },
+  "6": {
+    "id": "host.contract.account_missing",
+    "category": "contract",
+    "code": 6,
+    "name": "AccountMissingError",
+    "severity": "Error",
+    "since_protocol": 20,
+    "summary": "An account involved in the transaction does not exist on the network.",
+    "detailed_explanation": "The operation required a specific account to exist on the network, but the account could not be found.",
+    "common_causes": [
+      {
+        "description": "Providing an invalid account address or an account that has not been created/funded",
+        "likelihood": "high"
+      }
+    ],
+    "suggested_fixes": [
+      {
+        "description": "Verify that the addresses provided exist and are active on the target network",
+        "difficulty": "easy",
+        "requires_upgrade": false,
+        "related_errors": [],
+        "source_file": "soroban-env-host/src/host.rs"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
(closes #308)

## Summary

The `fetch-taxonomy` example previously wrote out the parsed TOML AST almost verbatim: `@iarna/toml` produces a deeply nested object graph that mirrors the Rust codebase's hierarchical namespaces, which forces the React frontend to traverse a tree on every render just to resolve an error code. This PR implements a custom recursive graph-walking algorithm that flattens the AST into a single-level dictionary keyed by numeric error code, so any code (e.g. `1042`) resolves to its definition in O(1) with zero recursive overhead at query time.

## What changed

### `examples/core-integration/fetch-taxonomy/index.js`

- **`flattenTaxonomy(root, options)`** — the core recursive graph walker. It dynamically iterates nested sections of the parsed TOML object via `Object.entries()`, distinguishing between:
  - **Structural grouping nodes** (plain associative objects such as `errors.contract.authentication`), which trigger further recursion, and
  - **Terminal leaf nodes** (error definition tables carrying a `name` string, description primitives, and a resolvable numeric code), which are extracted into the flat dictionary.
- **`resolveErrorCode(node, key)`** — resolves a definition's numeric key from `code`, `error_code`, or the enclosing table key (supporting both the `[[errors]]` array-of-tables shape used by `contract.toml` today and the `[errors.contract.authentication.1042]` namespace-section shape). Codes beyond `Number.MAX_SAFE_INTEGER` are preserved losslessly as strings.
- **`isErrorDefinition(node, key)` / `isPlainObject(value)`** — the leaf-vs-grouping classification predicates.
- **Fully defensive traversal** — if upstream Rust engineers introduce an unexpected data shape (a generic array or bare primitive where a definition table belongs, `null`, mixed arrays), the walker gracefully skips the anomalous node and logs a discrete warning with the offending path (e.g. `errors.contract.1042: expected an error definition table but found an array; node skipped`). A schema deviation can no longer trigger a fatal `TypeError: Cannot read properties of undefined`.
- **Duplicate protection** — duplicate error codes keep the first definition encountered and emit a warning instead of silently overwriting.
- `buildTaxonomyJson` now runs the sanitized AST through the flattener and writes the flat dictionary to `taxonomy.json`; it returns `{ serialized, dictionary, warnings }` and accepts an `onWarning` callback that the CLI entry point wires to `console.warn`.

### Output shape

`taxonomy.json` is now a single-level JSON object, drastically reducing the memory footprint and giving the React app instantaneous lookups:

```json
{
  "0": { "code": 0, "name": "ContractError", "summary": "..." },
  "6": { "code": 6, "name": "AccountMissingError", "summary": "..." }
}
```

### Tests (`index.test.js`)

The `node:test` suite grew from 2 to 8 tests, all passing:

- Flattens the array-of-tables (`[[errors]]`) shape keyed by the `code` field
- Resolves definitions nested arbitrarily deep in namespace sections with numeric table keys
- Skips anomalous shapes (arrays/primitives under numeric keys, `null`, mixed arrays) without crashing, while recording warnings and still extracting valid sibling definitions
- Keeps the first definition and warns on duplicate codes
- Does not mistake descriptive sub-tables (`common_causes`, `suggested_fixes`) for definitions
- End-to-end run against the real `crates/core/src/taxonomy/data/contract.toml` producing a flat, warning-free dictionary

### Docs

- `README.md` documents the flattening behaviour, the output shape, and the new `npm test` script.
- `package.json` gains a `test` script (`node --test`).

## Verification

```
$ npm test
ℹ tests 8
ℹ pass 8
ℹ fail 0

$ npm start
Wrote flattened taxonomy JSON (5 error codes) to examples\core-integration\fetch-taxonomy\taxonomy.json
```
