### PR TITLE
fix(cli-integration): raise stdout maxBuffer to 10 MB and capture stderr on success

### DIFF
--- a/examples/cli automation/cli integration/index.js
+++ b/examples/cli automation/cli integration/index.js
@@ -123,12 +123,26 @@ async function runPrism(args = []) {
   const start   = Date.now();
 
   try {
-    const { stdout } = await execFileAsync(binary, args, {
-      // Capture both streams as strings so we can inspect them on error.
+    const { stdout, stderr } = await execFileAsync(binary, args, {
+      // Capture both streams as UTF-8 strings so no output is lost.
       encoding: 'utf8',
       // Give long-running operations up to 5 minutes before we time out.
       timeout: 5 * 60 * 1000,
+      // Soroban envelope decodes can emit multi-megabyte JSON payloads, while
+      // Node.js caps a child's stdout at only 200 KB by default. Overflowing
+      // that cap kills the process with ERR_CHILD_PROCESS_STDIO_MAXBUFFER and
+      // discards the data. Raise the ceiling to 10 MB so large decodes stream
+      // through intact.
+      maxBuffer: 10 * 1024 * 1024,
     });
+
+    // Rust can write diagnostic or warning logs to stderr even on a
+    // successful (exit code 0) run. Surface them instead of dropping them so
+    // no crucial output is lost during the execution lifecycle.
+    const diagnostics = (stderr || '').trim();
+    if (diagnostics) {
+      console.warn(diagnostics);
+    }
 
     return stdout.trim();
   } catch (err) {


### PR DESCRIPTION
## Summary

Resolves the buffer-overflow crash and stderr-loss in the CLI integration helper at `examples/cli automation/cli integration/index.js`.

The wrapper already used `util.promisify(execFile)` with `async`/`await`, so the callback-style control flow was gone, but two gaps from the issue remained:

1. **No `maxBuffer` was configured.** The execution relied on Node's default 200 KB stdout cap. Because the grat Rust binary can emit multi-megabyte JSON when decoding large Soroban envelopes, the buffer would overflow and Node would kill the child with `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`, destroying the payload and crashing the integration.
2. **stderr was discarded on success.** Diagnostic/warning logs the binary writes to stderr on an exit-code-0 run were silently dropped.

## Changes

- Set `maxBuffer: 10 * 1024 * 1024` (10 MB) in the `execFileAsync` options so large decodes stream through without overflowing.
- Destructure and surface `stderr` on the success path (via `console.warn`) so diagnostic output is no longer lost during the execution lifecycle. stderr on failure was already captured and wrapped in `GratCliError`.

Both streams are now captured, and the async/await execution model is preserved.

## Testing

Pointed `PRISM_BIN` at a stub binary that writes ~500 KB to stdout (well over the old 200 KB cap) plus a stderr warning, then ran the wrapper end-to-end:

- Before: exceeding 200 KB triggers `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`.
- After: exit code 0, all 512001 bytes of stdout ingested intact, and the stderr diagnostic surfaced.

`node --check` passes on the modified file.

closes #310