### PR TITLE
#345 Task 32: No Metrics Exist to Detect Slow or Failing RPC Nodes in…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,5 +95,8 @@ crossterm = "0.28"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# Metrics / Observability
+prometheus = "0.13"
+
 # Shared internal crates
 grat-core = { path = "crates/core" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -44,6 +44,9 @@ flate2 = { workspace = true }
 # Logging
 tracing = { workspace = true }
 
+# Metrics / Observability
+prometheus = { workspace = true }
+
 # Error handling
 anyhow = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/core/src/rpc/client.rs
+++ b/crates/core/src/rpc/client.rs
@@ -246,6 +246,7 @@ impl SorobanRpcClient {
                 tracing::debug!(attempt, method, "Retrying RPC request");
             }
 
+            // Start the Prometheus latency timer before the network request.
             let started = Instant::now();
             tracing::debug!(method, endpoint = %self.rpc_url, attempt, "Sending RPC request");
 
@@ -253,7 +254,9 @@ impl SorobanRpcClient {
                 Ok(response) => {
                     let status = response.status();
                     let elapsed_ms = started.elapsed().as_millis();
+                    // Exact latency delta recorded into the HistogramVec.
                     let duration_secs = started.elapsed().as_secs_f64();
+                    crate::rpc::record_rpc_duration(&self.rpc_url, method, duration_secs);
                     tracing::info!(
                         method,
                         endpoint = %self.rpc_url,
@@ -264,7 +267,7 @@ impl SorobanRpcClient {
 
                     // Retry on 429 Too Many Requests.
                     if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-                        crate::rpc::record_rpc_duration(method, duration_secs, false);
+                        crate::rpc::record_rpc_http_error(&self.rpc_url, method, 429);
                         tracing::warn!(
                             method,
                             attempt,
@@ -278,7 +281,7 @@ impl SorobanRpcClient {
 
                     // Retry on any 5xx Server Error — these are transient node failures.
                     if status.is_server_error() {
-                        crate::rpc::record_rpc_duration(method, duration_secs, false);
+                        crate::rpc::record_rpc_http_error(&self.rpc_url, method, status.as_u16());
                         tracing::warn!(
                             method,
                             attempt,
@@ -293,7 +296,6 @@ impl SorobanRpcClient {
                     }
 
                     let body = response.text().await.map_err(|e| {
-                        crate::rpc::record_rpc_duration(method, duration_secs, false);
                         GratError::RpcError(format!("Failed to read response body: {e}"))
                     })?;
 
@@ -307,20 +309,23 @@ impl SorobanRpcClient {
                     );
 
                     if !status.is_success() {
-                        crate::rpc::record_rpc_duration(method, duration_secs, false);
+                        // Track non-retryable client/server HTTP failures as well.
+                        if status.as_u16() == 500 || status.as_u16() == 429 {
+                            crate::rpc::record_rpc_http_error(
+                                &self.rpc_url,
+                                method,
+                                status.as_u16(),
+                            );
+                        }
                         return Err(GratError::RpcError(format!(
                             "RPC request failed with HTTP {status}: {body}"
                         )));
                     }
 
-                    let rpc_response: JsonRpcResponse<T> =
-                        serde_json::from_str(&body).map_err(|e| {
-                            crate::rpc::record_rpc_duration(method, duration_secs, false);
-                            GratError::RpcError(format!("Response parse error: {e}"))
-                        })?;
+                    let rpc_response: JsonRpcResponse<T> = serde_json::from_str(&body)
+                        .map_err(|e| GratError::RpcError(format!("Response parse error: {e}")))?;
 
                     if let Some(err) = rpc_response.error {
-                        crate::rpc::record_rpc_duration(method, duration_secs, false);
                         tracing::debug!(
                             method,
                             endpoint = %self.rpc_url,
@@ -332,7 +337,6 @@ impl SorobanRpcClient {
                         return Err(GratError::JsonRpc(err));
                     }
 
-                    crate::rpc::record_rpc_duration(method, duration_secs, true);
                     return rpc_response
                         .result
                         .ok_or_else(|| GratError::RpcError("Empty result in RPC response".into()));
@@ -340,7 +344,7 @@ impl SorobanRpcClient {
                 Err(e) => {
                     let elapsed_ms = started.elapsed().as_millis();
                     let duration_secs = started.elapsed().as_secs_f64();
-                    crate::rpc::record_rpc_duration(method, duration_secs, false);
+                    crate::rpc::record_rpc_duration(&self.rpc_url, method, duration_secs);
                     tracing::info!(
                         method,
                         endpoint = %self.rpc_url,
@@ -869,6 +873,54 @@ mod tests {
             err_msg.to_lowercase().contains("timeout")
                 || err_msg.to_lowercase().contains("error sending request"),
             "Actual error: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn records_latency_histogram_on_success() {
+        let responses = vec![http_response(200, "OK", ok_body())];
+        let addr = spawn_mock_server(responses).await;
+        let client = make_client(addr);
+
+        let result = client.get_latest_ledger().await;
+        assert!(result.is_ok(), "expected success: {result:?}");
+
+        let exposition = crate::rpc::gather_rpc_metrics();
+        assert!(
+            exposition.contains("rpc_request_duration_seconds"),
+            "histogram missing from exposition:\n{exposition}"
+        );
+        assert!(
+            exposition.contains("getLatestLedger"),
+            "method label missing from exposition:\n{exposition}"
+        );
+    }
+
+    #[tokio::test]
+    async fn records_http_error_counter_on_500_and_429() {
+        // Exhaust retries so every attempt is an error that gets counted.
+        let responses = vec![
+            http_response(500, "Internal Server Error", ""),
+            http_response(429, "Too Many Requests", ""),
+            http_response(500, "Internal Server Error", ""),
+            http_response(429, "Too Many Requests", ""),
+        ];
+        let addr = spawn_mock_server(responses).await;
+        let _ = make_client(addr).get_latest_ledger().await;
+
+        let exposition = crate::rpc::gather_rpc_metrics();
+        assert!(
+            exposition.contains("rpc_http_errors_total"),
+            "error counter missing from exposition:\n{exposition}"
+        );
+        // At least one of the tracked statuses should appear.
+        assert!(
+            exposition.contains("500") || exposition.contains("429"),
+            "expected 500/429 status labels:\n{exposition}"
+        );
+        assert!(
+            exposition.contains("rpc_request_duration_seconds"),
+            "duration should still be recorded on error paths:\n{exposition}"
         );
     }
 

--- a/crates/core/src/rpc/jsonrpc.rs
+++ b/crates/core/src/rpc/jsonrpc.rs
@@ -132,6 +132,7 @@ impl JsonRpcTransport {
                 tracing::debug!(attempt, method, "retrying RPC request");
             }
 
+            // Start the Prometheus latency timer before the network request.
             let started_at = Instant::now();
             tracing::debug!(method, endpoint = %self.endpoint, attempt, "sending RPC request");
 
@@ -139,7 +140,9 @@ impl JsonRpcTransport {
                 Ok(response) => {
                     let status = response.status();
                     let elapsed_ms = started_at.elapsed().as_millis();
+                    // Exact latency delta recorded into the HistogramVec.
                     let duration_secs = started_at.elapsed().as_secs_f64();
+                    crate::rpc::record_rpc_duration(&self.endpoint, method, duration_secs);
 
                     tracing::debug!(
                         method,
@@ -151,7 +154,7 @@ impl JsonRpcTransport {
                     );
 
                     if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-                        crate::rpc::record_rpc_duration(method, duration_secs, false);
+                        crate::rpc::record_rpc_http_error(&self.endpoint, method, 429);
                         tracing::warn!(method, attempt, "rate limited by RPC endpoint, will retry");
                         last_error = Some(GratError::RpcError(format!(
                             "rate limited (attempt {attempt})"
@@ -160,7 +163,7 @@ impl JsonRpcTransport {
                     }
 
                     if status.is_server_error() {
-                        crate::rpc::record_rpc_duration(method, duration_secs, false);
+                        crate::rpc::record_rpc_http_error(&self.endpoint, method, status.as_u16());
                         tracing::warn!(
                             method,
                             attempt,
@@ -174,21 +177,17 @@ impl JsonRpcTransport {
                         continue;
                     }
 
-                    let body = response.text().await.map_err(|e| {
-                        crate::rpc::record_rpc_duration(method, duration_secs, false);
-                        GratError::RpcError(format!("response read error: {e}"))
-                    })?;
+                    let body = response
+                        .text()
+                        .await
+                        .map_err(|e| GratError::RpcError(format!("response read error: {e}")))?;
 
                     tracing::trace!(method, elapsed_ms, response = %body, "RPC response payload");
 
-                    let envelope: JsonRpcResponse<R> =
-                        serde_json::from_str(&body).map_err(|e| {
-                            crate::rpc::record_rpc_duration(method, duration_secs, false);
-                            GratError::RpcError(format!("response parse error: {e}"))
-                        })?;
+                    let envelope: JsonRpcResponse<R> = serde_json::from_str(&body)
+                        .map_err(|e| GratError::RpcError(format!("response parse error: {e}")))?;
 
                     if let Some(err) = envelope.error {
-                        crate::rpc::record_rpc_duration(method, duration_secs, false);
                         tracing::debug!(
                             method,
                             endpoint = %self.endpoint,
@@ -199,14 +198,13 @@ impl JsonRpcTransport {
                         return Err(GratError::JsonRpc(err));
                     }
 
-                    crate::rpc::record_rpc_duration(method, duration_secs, true);
                     return envelope
                         .result
                         .ok_or_else(|| GratError::RpcError("empty result".to_string()));
                 }
                 Err(e) => {
                     let duration_secs = started_at.elapsed().as_secs_f64();
-                    crate::rpc::record_rpc_duration(method, duration_secs, false);
+                    crate::rpc::record_rpc_duration(&self.endpoint, method, duration_secs);
                     tracing::debug!(
                         method,
                         endpoint = %self.endpoint,

--- a/crates/core/src/rpc/metrics.rs
+++ b/crates/core/src/rpc/metrics.rs
@@ -1,122 +1,113 @@
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::sync::{Mutex, OnceLock};
+//! Prometheus instrumentation for Soroban RPC client traffic.
+//!
+//! Exposes a global static metrics registry with:
+//! - `rpc_request_duration_seconds` — [`HistogramVec`] labeled by `endpoint` and `method`
+//! - `rpc_http_errors_total` — [`CounterVec`] labeled by `endpoint`, `method`, and `status`
+//!   tracking HTTP 500 / 429 responses in real time.
+//!
+//! Call [`gather`] to produce a Prometheus text exposition payload suitable for
+//! scraping by Grafana / Prometheus.
 
-const BUCKETS: &[f64] = &[
+use prometheus::{
+    opts, register_counter_vec, register_histogram_vec, CounterVec, Encoder, HistogramOpts,
+    HistogramVec, TextEncoder,
+};
+use std::sync::OnceLock;
+
+/// Default latency buckets (seconds) covering sub-millisecond to multi-second RPCs.
+const DURATION_BUCKETS: &[f64] = &[
     0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
 ];
 
-#[derive(Debug, Serialize, Deserialize)]
-struct Histogram {
-    bucket_counts: Vec<u64>,
-
-    count: u64,
-
-    sum: f64,
+/// Global static metrics registry holders.
+struct RpcMetrics {
+    /// Histogram of RPC request latencies, labeled by endpoint URL and JSON-RPC method.
+    request_duration: HistogramVec,
+    /// Counter of HTTP 500 / 429 (and other tracked error statuses) responses.
+    http_errors: CounterVec,
 }
 
-impl Histogram {
-    fn new() -> Self {
-        Self {
-            bucket_counts: vec![0u64; BUCKETS.len()],
-            count: 0,
-            sum: 0.0,
+static METRICS: OnceLock<RpcMetrics> = OnceLock::new();
+
+fn metrics() -> &'static RpcMetrics {
+    METRICS.get_or_init(|| {
+        let request_duration = register_histogram_vec!(
+            HistogramOpts::new(
+                "rpc_request_duration_seconds",
+                "Duration of Soroban RPC requests in seconds"
+            )
+            .buckets(DURATION_BUCKETS.to_vec()),
+            &["endpoint", "method"]
+        )
+        .expect("failed to register rpc_request_duration_seconds histogram");
+
+        let http_errors = register_counter_vec!(
+            opts!(
+                "rpc_http_errors_total",
+                "Total number of HTTP error responses from Soroban RPC nodes (e.g. 500, 429)"
+            ),
+            &["endpoint", "method", "status"]
+        )
+        .expect("failed to register rpc_http_errors_total counter");
+
+        RpcMetrics {
+            request_duration,
+            http_errors,
         }
-    }
-
-    fn observe(&mut self, value: f64) {
-        self.count += 1;
-        self.sum += value;
-
-        for (i, &bound) in BUCKETS.iter().enumerate() {
-            if value <= bound {
-                self.bucket_counts[i] += 1;
-            }
-        }
-    }
-
-    fn render(&self, method: &str, outcome: &str, out: &mut String) {
-        let mut cumulative = 0u64;
-
-        for (i, &bound) in BUCKETS.iter().enumerate() {
-            cumulative += self.bucket_counts[i];
-            out.push_str(&format!(
-                "rpc_request_duration_seconds_bucket\
-                 {{method=\"{method}\",outcome=\"{outcome}\",le=\"{bound}\"}} {cumulative}\n"
-            ));
-        }
-
-        out.push_str(&format!(
-            "rpc_request_duration_seconds_bucket\
-             {{method=\"{method}\",outcome=\"{outcome}\",le=\"+Inf\"}} {}\n",
-            self.count
-        ));
-        out.push_str(&format!(
-            "rpc_request_duration_seconds_count\
-             {{method=\"{method}\",outcome=\"{outcome}\"}} {}\n",
-            self.count
-        ));
-        out.push_str(&format!(
-            "rpc_request_duration_seconds_sum\
-             {{method=\"{method}\",outcome=\"{outcome}\"}} {:.9}\n",
-            self.sum
-        ));
-    }
+    })
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
-pub struct RpcMetricsRegistry {
-    histograms: HashMap<String, Histogram>,
+/// Record the observed latency of an RPC call against the global histogram.
+///
+/// Labels:
+/// - `endpoint` — the RPC node URL
+/// - `method` — the JSON-RPC method name (e.g. `getTransaction`, `getLedgerEntries`)
+pub fn record_rpc_duration(endpoint: &str, method: &str, duration_secs: f64) {
+    metrics()
+        .request_duration
+        .with_label_values(&[endpoint, method])
+        .observe(duration_secs);
 }
 
-impl RpcMetricsRegistry {
-    pub fn record(&mut self, method: &str, duration_secs: f64, success: bool) {
-        let outcome = if success { "success" } else { "error" };
-        let key = format!("{method}:{outcome}");
-        self.histograms
-            .entry(key)
-            .or_insert_with(Histogram::new)
-            .observe(duration_secs);
-    }
-
-    pub fn gather(&self) -> String {
-        let mut out = String::with_capacity(512);
-        out.push_str(
-            "# HELP rpc_request_duration_seconds \
-             Duration of Soroban RPC requests in seconds.\n",
-        );
-        out.push_str("# TYPE rpc_request_duration_seconds histogram\n");
-
-        let mut keys: Vec<&String> = self.histograms.keys().collect();
-        keys.sort();
-
-        for key in keys {
-            let hist = &self.histograms[key];
-            let (method, outcome) = key.split_once(':').unwrap_or((key.as_str(), "unknown"));
-            hist.render(method, outcome, &mut out);
-        }
-
-        out
-    }
+/// Backward-compatible wrapper used by call sites that only know method + outcome.
+///
+/// Records duration under a synthetic endpoint label `"unknown"` so existing
+/// instrumentation keeps compiling while new call sites migrate to the
+/// endpoint-aware API.
+pub fn record_rpc_duration_simple(method: &str, duration_secs: f64, _success: bool) {
+    record_rpc_duration("unknown", method, duration_secs);
 }
 
-static REGISTRY: OnceLock<Mutex<RpcMetricsRegistry>> = OnceLock::new();
-
-fn registry() -> &'static Mutex<RpcMetricsRegistry> {
-    REGISTRY.get_or_init(|| Mutex::new(RpcMetricsRegistry::default()))
+/// Increment the HTTP error counter for a given status code (typically 500 or 429).
+pub fn record_rpc_http_error(endpoint: &str, method: &str, status: u16) {
+    metrics()
+        .http_errors
+        .with_label_values(&[endpoint, method, &status.to_string()])
+        .inc();
 }
 
-pub fn record_rpc_duration(method: &str, duration_secs: f64, success: bool) {
-    if let Ok(mut reg) = registry().lock() {
-        reg.record(method, duration_secs, success);
-    }
-}
-
+/// Gather all registered Prometheus metrics as a text exposition string.
+///
+/// Suitable for serving on a `/metrics` HTTP endpoint consumed by Grafana.
 pub fn gather() -> String {
-    registry()
-        .lock()
-        .map(|reg| reg.gather())
-        .unwrap_or_default()
+    // Ensure metrics are registered even if no RPC calls have been made yet.
+    let _ = metrics();
+
+    let encoder = TextEncoder::new();
+    let metric_families = prometheus::gather();
+    let mut buffer = Vec::new();
+    if encoder.encode(&metric_families, &mut buffer).is_err() {
+        return String::new();
+    }
+    String::from_utf8(buffer).unwrap_or_default()
+}
+
+/// Convenience re-export so call sites can use `crate::rpc::record_rpc_duration`
+/// with the legacy (method, duration, success) signature during migration.
+/// Prefer [`record_rpc_duration`] with the endpoint label for new code.
+#[inline]
+pub fn record_rpc_duration_compat(method: &str, duration_secs: f64, success: bool) {
+    record_rpc_duration_simple(method, duration_secs, success);
 }
 
 #[cfg(test)]
@@ -124,147 +115,98 @@ mod tests {
     use super::*;
 
     #[test]
-    fn histogram_starts_empty() {
-        let h = Histogram::new();
-        assert_eq!(h.count, 0);
-        assert_eq!(h.sum, 0.0);
-        assert!(h.bucket_counts.iter().all(|&c| c == 0));
-    }
-
-    #[test]
-    fn histogram_observe_increments_count_and_sum() {
-        let mut h = Histogram::new();
-        h.observe(0.05);
-        h.observe(0.5);
-        h.observe(5.0);
-
-        assert_eq!(h.count, 3);
-        assert!((h.sum - 5.55).abs() < 1e-9, "sum mismatch: {}", h.sum);
-    }
-
-    #[test]
-    fn histogram_buckets_are_cumulative() {
-        let mut h = Histogram::new();
-        h.observe(0.08);
-
-        let idx_005 = 0;
-        let idx_01 = 1;
-        let idx_025 = 2;
-        let idx_05 = 3;
-        let idx_01_s = 4;
-
-        assert_eq!(h.bucket_counts[idx_005], 0);
-        assert_eq!(h.bucket_counts[idx_01], 0);
-        assert_eq!(h.bucket_counts[idx_025], 0);
-        assert_eq!(h.bucket_counts[idx_05], 0);
-        assert_eq!(h.bucket_counts[idx_01_s], 1);
-    }
-
-    #[test]
-    fn histogram_value_below_all_buckets_increments_first() {
-        let mut h = Histogram::new();
-        h.observe(0.001);
-        assert_eq!(h.bucket_counts[0], 1);
-    }
-
-    #[test]
-    fn histogram_value_above_all_buckets_not_in_finite_buckets() {
-        let mut h = Histogram::new();
-        h.observe(100.0);
-        assert!(
-            h.bucket_counts.iter().all(|&c| c == 0),
-            "value above all bounds should not increment any finite bucket"
-        );
-        assert_eq!(h.count, 1, "+Inf bucket == count");
-    }
-
-    #[test]
-    fn registry_separates_success_and_error() {
-        let mut reg = RpcMetricsRegistry::default();
-        reg.record("getTransaction", 0.1, true);
-        reg.record("getTransaction", 0.2, false);
-
-        assert_eq!(reg.histograms.len(), 2);
-        assert!(reg.histograms.contains_key("getTransaction:success"));
-        assert!(reg.histograms.contains_key("getTransaction:error"));
-    }
-
-    #[test]
-    fn registry_separates_methods() {
-        let mut reg = RpcMetricsRegistry::default();
-        reg.record("getTransaction", 0.1, true);
-        reg.record("simulateTransaction", 0.5, true);
-
-        assert_eq!(reg.histograms.len(), 2);
-    }
-
-    #[test]
-    fn gather_contains_help_and_type_lines() {
-        let reg = RpcMetricsRegistry::default();
-        let output = reg.gather();
-        assert!(output.contains("# HELP rpc_request_duration_seconds"));
-        assert!(output.contains("# TYPE rpc_request_duration_seconds histogram"));
-    }
-
-    #[test]
-    fn gather_produces_correct_labels() {
-        let mut reg = RpcMetricsRegistry::default();
-        reg.record("getLatestLedger", 0.042, true);
-
-        let output = reg.gather();
-        assert!(output.contains("method=\"getLatestLedger\""));
-        assert!(output.contains("outcome=\"success\""));
-        assert!(output.contains("le=\"+Inf\""));
-    }
-
-    #[test]
-    fn gather_inf_bucket_equals_count() {
-        let mut reg = RpcMetricsRegistry::default();
-        reg.record("getLedgerEntries", 0.3, true);
-        reg.record("getLedgerEntries", 0.7, true);
-        reg.record("getLedgerEntries", 1.2, true);
-
-        let output = reg.gather();
-        assert!(
-            output.contains(
-                "rpc_request_duration_seconds_bucket\
-                 {method=\"getLedgerEntries\",outcome=\"success\",le=\"+Inf\"} 3"
-            ),
-            "unexpected output:\n{output}"
-        );
-        assert!(
-            output.contains(
-                "rpc_request_duration_seconds_count\
-                 {method=\"getLedgerEntries\",outcome=\"success\"} 3"
-            ),
-            "unexpected output:\n{output}"
-        );
-    }
-
-    #[test]
-    fn gather_output_is_sorted_by_key() {
-        let mut reg = RpcMetricsRegistry::default();
-        reg.record("simulateTransaction", 0.1, true);
-        reg.record("getTransaction", 0.2, true);
-
-        let output = reg.gather();
-        let pos_get = output.find("method=\"getTransaction\"").unwrap();
-        let pos_sim = output.find("method=\"simulateTransaction\"").unwrap();
-        assert!(
-            pos_get < pos_sim,
-            "getTransaction should appear before simulateTransaction"
-        );
+    fn metrics_register_without_panic() {
+        // Force lazy init.
+        let _ = metrics();
     }
 
     #[test]
     fn record_rpc_duration_does_not_panic() {
-        record_rpc_duration("getLatestLedger", 0.042, true);
-        record_rpc_duration("getLatestLedger", 1.500, false);
+        record_rpc_duration(
+            "https://soroban-testnet.stellar.org",
+            "getLatestLedger",
+            0.042,
+        );
+        record_rpc_duration(
+            "https://soroban-testnet.stellar.org",
+            "getTransaction",
+            1.500,
+        );
     }
 
     #[test]
-    fn global_gather_returns_prometheus_header() {
+    fn record_rpc_http_error_tracks_500_and_429() {
+        let endpoint = "https://soroban-testnet.stellar.org";
+        record_rpc_http_error(endpoint, "getTransaction", 500);
+        record_rpc_http_error(endpoint, "getTransaction", 429);
+        record_rpc_http_error(endpoint, "getLedgerEntries", 500);
+
         let output = gather();
-        assert!(output.contains("# HELP rpc_request_duration_seconds"));
+        assert!(
+            output.contains("rpc_http_errors_total"),
+            "expected http error counter in exposition:\n{output}"
+        );
+        assert!(
+            output.contains("500") || output.contains("status=\"500\""),
+            "expected status 500 label:\n{output}"
+        );
+        assert!(
+            output.contains("429") || output.contains("status=\"429\""),
+            "expected status 429 label:\n{output}"
+        );
+    }
+
+    #[test]
+    fn gather_contains_histogram_help_and_type() {
+        record_rpc_duration("https://example.com/rpc", "getLatestLedger", 0.01);
+        let output = gather();
+        assert!(
+            output.contains("rpc_request_duration_seconds"),
+            "missing histogram name:\n{output}"
+        );
+        assert!(
+            output.contains("# HELP rpc_request_duration_seconds")
+                || output.contains("rpc_request_duration_seconds_bucket")
+                || output.contains("rpc_request_duration_seconds_count"),
+            "unexpected exposition format:\n{output}"
+        );
+    }
+
+    #[test]
+    fn gather_includes_endpoint_and_method_labels() {
+        let endpoint = "https://rpc.example.com";
+        let method = "simulateTransaction";
+        record_rpc_duration(endpoint, method, 0.25);
+
+        let output = gather();
+        assert!(
+            output.contains("endpoint=") || output.contains(endpoint),
+            "expected endpoint label in output:\n{output}"
+        );
+        assert!(
+            output.contains("method=") || output.contains(method),
+            "expected method label in output:\n{output}"
+        );
+    }
+
+    #[test]
+    fn record_rpc_duration_simple_compat_works() {
+        record_rpc_duration_simple("getEvents", 0.1, true);
+        record_rpc_duration_simple("getEvents", 0.2, false);
+        let output = gather();
+        assert!(output.contains("rpc_request_duration_seconds"));
+    }
+
+    #[test]
+    fn histogram_buckets_include_expected_bounds() {
+        record_rpc_duration("https://rpc.example.com", "getLedgerEntries", 0.08);
+        let output = gather();
+        // Prometheus histogram exposition emits le="<bound>" labels.
+        assert!(
+            output.contains("le=\"0.1\"")
+                || output.contains("le=\"0.25\"")
+                || output.contains("le=\"+Inf\""),
+            "expected standard bucket bounds in exposition:\n{output}"
+        );
     }
 }

--- a/crates/core/src/rpc/mod.rs
+++ b/crates/core/src/rpc/mod.rs
@@ -6,4 +6,7 @@ pub use client::{
     SimulateAuthEntry, SimulateCost, SimulateFootprint, SimulateResult, SimulateSorobanData,
     SimulateTransactionResponse, SorobanRpcClient,
 };
-pub use metrics::{gather as gather_rpc_metrics, record_rpc_duration};
+pub use metrics::{
+    gather as gather_rpc_metrics, record_rpc_duration, record_rpc_duration_simple,
+    record_rpc_http_error,
+};


### PR DESCRIPTION
### Findings
- **Grat** is a Soroban transaction debugger (CLI + core + web/server). Production load is dominated by **external Soroban RPC latency**.
- Without solid observability, operators cannot see node degradation, route to healthier RPCs, or scale on real signals.
- The issue required Prometheus instrumentation on `SorobanRpcClient`:
  - global static metrics registry  
  - `HistogramVec` for `rpc_request_duration_seconds` (endpoint + method)  
  - `Instant::now()` around network calls, record latency on success/failure  
  - `CounterVec` for HTTP **500** / **429** error rates  
- What was already in the tree was a **hand-rolled** histogram in `metrics.rs` (method/outcome only), **not** the real `prometheus` crate, **no endpoint labels**, and **no 500/429 counters** — not Grafana/enterprise ready.

### Fix features
1. **Real `prometheus` crate** wired into `grat-core` (workspace + crate deps).
2. **Global static registry** via `OnceLock` + Prometheus registration macros.
3. **`rpc_request_duration_seconds`** — `HistogramVec` labeled by **`endpoint`** and **`method`**.
4. **`rpc_http_errors_total`** — `CounterVec` labeled by **`endpoint`**, **`method`**, and **`status`** (500, 429, other 5xx).
5. **Timers in the request path** (`Instant::now()` before send) in:
   - `crates/core/src/rpc/client.rs` (`SorobanRpcClient::call`)
   - `crates/core/src/rpc/jsonrpc.rs` (`JsonRpcTransport::call`)
6. Latency recorded on **success and failure** (including retries / transport errors).
7. Error counter incremented on **429** and **5xx** responses.
8. **`gather()` / `gather_rpc_metrics()`** — Prometheus text exposition for Grafana scrapes.
9. Standard latency buckets: `0.005 … 10.0` seconds.
10. Tests covering histogram labels, 500/429 counters, and existing RPC retry/timeout behavior (all passing).


CLOSE #345 