### PR TITLE
taxonomy: complete suggested_fixes coverage for budget, storage, and contract errors (#349)

### DIFF
--- a/crates/core/src/taxonomy/data/budget.toml
+++ b/crates/core/src/taxonomy/data/budget.toml
@@ -185,5 +185,10 @@ description = "Profile the contract and reduce unnecessary computation before it
 difficulty = "medium"
 requires_upgrade = true
 
+[[errors.suggested_fixes]]
+description = "Add resource metering logs to your CI pipeline to catch contracts trending toward the limit before deploy"
+difficulty = "medium"
+requires_upgrade = false
+
 related_errors = ["host.budget.limit_exceeded.cpu"]
 source_file = "soroban-env-host/src/budget.rs"

--- a/crates/core/src/taxonomy/data/contract.toml
+++ b/crates/core/src/taxonomy/data/contract.toml
@@ -71,6 +71,11 @@ description = "Check the diagnostic logs to see if there are internal contract a
 difficulty = "medium"
 requires_upgrade = false
 
+[[errors.suggested_fixes]]
+description = "Compare host and SDK versions between simulation and submission to rule out a protocol mismatch"
+difficulty = "medium"
+requires_upgrade = false
+
 related_errors = []
 source_file = "soroban-env-host/src/host.rs"
 
@@ -94,6 +99,11 @@ likelihood = "high"
 
 [[errors.suggested_fixes]]
 description = "Check the asset flags and ensure the operation is allowed for the target asset"
+difficulty = "easy"
+requires_upgrade = false
+
+[[errors.suggested_fixes]]
+description = "Re-check the asset's issuer-set flags (e.g. AUTH_REQUIRED, CLAWBACK_ENABLED) before invoking the operation"
 difficulty = "easy"
 requires_upgrade = false
 
@@ -122,6 +132,11 @@ description = "Ensure that initialization is only called once per contract deplo
 difficulty = "easy"
 requires_upgrade = false
 
+[[errors.suggested_fixes]]
+description = "Guard the initialize function with a storage check (e.g. instance storage has_key) that early-returns if already set"
+difficulty = "easy"
+requires_upgrade = false
+
 related_errors = []
 source_file = "soroban-env-host/src/host.rs"
 
@@ -144,6 +159,11 @@ likelihood = "high"
 
 [[errors.suggested_fixes]]
 description = "Verify that the addresses provided exist and are active on the target network"
+difficulty = "easy"
+requires_upgrade = false
+
+[[errors.suggested_fixes]]
+description = "Fund and create the account on the target network before invoking the contract that references it"
 difficulty = "easy"
 requires_upgrade = false
 

--- a/crates/core/src/taxonomy/data/storage.toml
+++ b/crates/core/src/taxonomy/data/storage.toml
@@ -141,13 +141,8 @@ difficulty = "hard"
 requires_upgrade = false
 
 [[errors.suggested_fixes]]
-description = "Inspect diagnostic events for the ledger key or storage operation that failed"
-difficulty = "medium"
-requires_upgrade = false
-
-[[errors.suggested_fixes]]
-description = "Retry on a fresh ledger state or report the transaction if the failure is reproducible"
-difficulty = "medium"
+description = "Retry the operation against a fresh ledger snapshot to rule out transient state corruption"
+difficulty = "easy"
 requires_upgrade = false
 
 [[errors]]
@@ -181,5 +176,3 @@ requires_upgrade = true
 
 related_errors = ["host.storage.entry_not_found"]
 source_file = "soroban-env-host/src/storage.rs"
-
-


### PR DESCRIPTION
Closes #349

## Context
The issue asked for the taxonomy schema to support `suggested_fixes` and
for budget.toml, storage.toml, auth.toml, and contract.toml to be updated
with 2-3 actionable fixes per error entry.

On inspection, `schema.rs` already defines `suggested_fixes` as a
structured `Vec<TaxonomyFix>` (description, difficulty, requires_upgrade,
example), and both the terminal formatter (`crates/cli/src/output/human.rs`)
and the web UI (`apps/web/src/components/decode/ErrorCard.tsx`) already
render these as bulleted checklists. `auth.toml` already had 2 fixes on
every entry. So this PR focuses on the remaining data gaps rather than
re-doing work that was already in place.

## Changes
- **budget.toml**: added a second fix to `host.budget.approaching_limit`
  (previously had only 1).
- **storage.toml**: `host.storage.internal_error` had 4 fixes, but two
  were near-duplicates of the other two. Cleaned this up to 3 distinct,
  actionable fixes.
- **contract.toml**: added a second fix to each of the 4 entries that
  previously had only 1 — `host.contract.internal_error`,
  `host.contract.operation_not_supported`,
  `host.contract.already_initialized`, and
  `host.contract.account_missing`.
- **auth.toml**: no changes needed, already complete.
- **schema.rs**: no changes needed, `suggested_fixes` already supported.

## Result
Every entry in budget.toml, storage.toml, auth.toml, and contract.toml
now has 2-3 suggested fixes, matching the goal in #349 — developers now
get concrete remediation steps in both the CLI and web output instead of
just an error name.

## Testing
- `cargo test -p prism-core taxonomy` passes
- Verified all edited TOML files parse correctly