### PR TITLE
Add rigorous ContractId validation type

### DIFF
--- a/crates/core/src/decode/contract_error.rs
+++ b/crates/core/src/decode/contract_error.rs
@@ -1,8 +1,8 @@
 use crate::decode::decode_context::DecodeContext;
 use crate::error::{GratError, GratResult};
 use crate::spec::decoder;
-use crate::types::contract_id::ContractId;
 use crate::types::config::NetworkConfig;
+use crate::types::contract_id::ContractId;
 use crate::types::report::ContractErrorInfo;
 
 pub async fn resolve(

--- a/crates/core/src/decode/contract_error.rs
+++ b/crates/core/src/decode/contract_error.rs
@@ -1,7 +1,7 @@
 use crate::decode::decode_context::DecodeContext;
 use crate::error::{GratError, GratResult};
 use crate::spec::decoder;
-use crate::types::address::Address;
+use crate::types::contract_id::ContractId;
 use crate::types::config::NetworkConfig;
 use crate::types::report::ContractErrorInfo;
 
@@ -18,7 +18,7 @@ async fn resolve_with_network(
     error_code: u32,
     network: &NetworkConfig,
 ) -> GratResult<ContractErrorInfo> {
-    Address::validate_contract_id(contract_id)?;
+    ContractId::new(contract_id)?;
 
     let cache = crate::cache::store::CacheStore::default_location()?;
     let cache_key = format!("{contract_id}_spec");

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -83,6 +83,9 @@ pub enum GratError {
 
     #[error("Transaction succeeded — no error to decode")]
     TransactionSucceeded,
+
+    #[error("Invalid Contract ID: {0}")]
+    InvalidContractId(String),
 }
 
 pub type GratResult<T> = Result<T, GratError>;

--- a/crates/core/src/types/contract_id.rs
+++ b/crates/core/src/types/contract_id.rs
@@ -1,4 +1,3 @@
-
 use crate::error::GratError;
 use std::convert::TryFrom;
 use std::fmt;
@@ -9,7 +8,6 @@ const CONTRACT_ID_LEN: usize = 56;
 pub struct ContractId(String);
 
 impl ContractId {
-    
     pub fn new(raw: impl Into<String>) -> Result<Self, GratError> {
         let raw = raw.into();
         validate_contract_id(&raw)?;
@@ -69,10 +67,7 @@ fn validate_contract_id(raw: &str) -> Result<(), GratError> {
     }
 
     stellar_strkey::Contract::from_string(raw).map_err(|e| {
-        GratError::InvalidContractId(format!(
-            "'{}' is not valid StrKey-encoded data: {}",
-            raw, e
-        ))
+        GratError::InvalidContractId(format!("'{}' is not valid StrKey-encoded data: {}", raw, e))
     })?;
 
     Ok(())
@@ -109,10 +104,13 @@ mod tests {
 
     #[test]
     fn rejects_bad_checksum() {
-        
         let mut raw = valid_contract_id();
         let last = raw.len() - 1;
-        let corrupted_char = if raw.as_bytes()[last] == b'A' { 'B' } else { 'A' };
+        let corrupted_char = if raw.as_bytes()[last] == b'A' {
+            'B'
+        } else {
+            'A'
+        };
         raw.replace_range(last..last + 1, &corrupted_char.to_string());
         assert!(ContractId::new(raw).is_err());
     }
@@ -120,7 +118,7 @@ mod tests {
     #[test]
     fn rejects_invalid_base32_char() {
         let mut raw = valid_contract_id();
-        raw.replace_range(10..11, "0"); 
+        raw.replace_range(10..11, "0");
         assert!(ContractId::new(raw).is_err());
     }
 

--- a/crates/core/src/types/contract_id.rs
+++ b/crates/core/src/types/contract_id.rs
@@ -1,0 +1,133 @@
+
+use crate::error::GratError;
+use std::convert::TryFrom;
+use std::fmt;
+
+const CONTRACT_ID_LEN: usize = 56;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ContractId(String);
+
+impl ContractId {
+    
+    pub fn new(raw: impl Into<String>) -> Result<Self, GratError> {
+        let raw = raw.into();
+        validate_contract_id(&raw)?;
+        Ok(Self(raw))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ContractId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl TryFrom<String> for ContractId {
+    type Error = GratError;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        ContractId::new(value)
+    }
+}
+
+impl TryFrom<&str> for ContractId {
+    type Error = GratError;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        ContractId::new(value)
+    }
+}
+
+fn validate_contract_id(raw: &str) -> Result<(), GratError> {
+    if raw.len() != CONTRACT_ID_LEN {
+        return Err(GratError::InvalidContractId(format!(
+            "expected {} characters, got {} (received '{}')",
+            CONTRACT_ID_LEN,
+            raw.len(),
+            raw
+        )));
+    }
+
+    match raw.as_bytes()[0] {
+        b'C' => {}
+        b'G' => {
+            return Err(GratError::InvalidContractId(format!(
+                "Must start with 'C', but received 'G' — this looks like an \
+                 Account ID, not a Contract ID: '{}'",
+                raw
+            )))
+        }
+        other => {
+            return Err(GratError::InvalidContractId(format!(
+                "Must start with 'C', but received '{}': '{}'",
+                other as char, raw
+            )))
+        }
+    }
+
+    stellar_strkey::Contract::from_string(raw).map_err(|e| {
+        GratError::InvalidContractId(format!(
+            "'{}' is not valid StrKey-encoded data: {}",
+            raw, e
+        ))
+    })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_contract_id() -> String {
+        let bytes = [7u8; 32];
+        stellar_strkey::Contract(bytes).to_string()
+    }
+
+    #[test]
+    fn accepts_valid_contract_id() {
+        let raw = valid_contract_id();
+        assert!(ContractId::new(raw).is_ok());
+    }
+
+    #[test]
+    fn rejects_wrong_length() {
+        let err = ContractId::new("CABCDEFG").unwrap_err();
+        assert!(matches!(err, GratError::InvalidContractId(msg) if msg.contains("56 characters")));
+    }
+
+    #[test]
+    fn rejects_account_id_prefix() {
+        let mut raw = valid_contract_id();
+        raw.replace_range(0..1, "G");
+        let err = ContractId::new(raw).unwrap_err();
+        assert!(matches!(err, GratError::InvalidContractId(msg) if msg.contains("Account ID")));
+    }
+
+    #[test]
+    fn rejects_bad_checksum() {
+        
+        let mut raw = valid_contract_id();
+        let last = raw.len() - 1;
+        let corrupted_char = if raw.as_bytes()[last] == b'A' { 'B' } else { 'A' };
+        raw.replace_range(last..last + 1, &corrupted_char.to_string());
+        assert!(ContractId::new(raw).is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_base32_char() {
+        let mut raw = valid_contract_id();
+        raw.replace_range(10..11, "0"); 
+        assert!(ContractId::new(raw).is_err());
+    }
+
+    #[test]
+    fn try_from_str_works() {
+        let raw = valid_contract_id();
+        let cid = ContractId::try_from(raw.as_str()).unwrap();
+        assert_eq!(cid.as_str(), raw);
+    }
+}

--- a/crates/core/src/types/mod.rs
+++ b/crates/core/src/types/mod.rs
@@ -1,5 +1,5 @@
 pub mod address;
 pub mod config;
+pub mod contract_id;
 pub mod report;
 pub mod trace;
-pub mod contract_id;

--- a/crates/core/src/types/mod.rs
+++ b/crates/core/src/types/mod.rs
@@ -2,3 +2,4 @@ pub mod address;
 pub mod config;
 pub mod report;
 pub mod trace;
+pub mod contract_id;


### PR DESCRIPTION
Closes #330 

## What
Adds a validated `ContractId` newtype so malformed contract IDs (e.g. an
Account ID starting with `G`, or a raw tx hash) are rejected at the perimeter
instead of silently flowing into the RPC client / WASM fetcher and surfacing
as opaque HTTP 404s or unrelated crypto errors downstream.

## Changes
- **New:** `crates/core/src/types/contract_id.rs` — `ContractId` wraps a
  `String` and can only be constructed via `ContractId::new`/`TryFrom`, which
  validates:
  1. Exactly 56 characters
  2. Valid StrKey base32 **and checksum**, via `stellar_strkey::Contract::from_string`
     (already a workspace dependency — stronger than a plain charset check,
     since it also validates the embedded CRC16 checksum)
  3. Starts with `'C'` — with a specific diagnostic when it instead starts
     with `'G'`, since that's the most common real-world mistake
- `crates/core/src/error.rs` — new `GratError::InvalidContractId(String)` variant
- `crates/core/src/types/address.rs` — `Address::validate_contract_id` now
  delegates to `ContractId::new` (single source of truth), remapping the
  error back to `InvalidAddress` for backward compatibility. Two existing
  test assertions were updated to match the new message text.
- `crates/core/src/decode/contract_error.rs` — `resolve_with_network` now
  validates via `ContractId::new` before any cache lookup or RPC call,
  instead of `Address::validate_contract_id`

## Testing
- `cargo build` — clean
- `cargo test -p grat-core` — 243/243 passing, including 6 new tests in
  `types::contract_id` (valid input, wrong length, `G`-prefix, bad checksum,
  invalid base32 char, `TryFrom`) and updated `types::address` tests

## Notes for reviewers
- `Address::validate_contract_id`'s error message changed slightly (now
  says "Must start with 'C'" and names the Account ID mistake explicitly) —
  reflected in the updated test assertions, not a behavior regression.
- `spec/resolver.rs` has an existing `pub type ContractId = String;` alias
  used purely as a cache key. It doesn't collide with the new struct today
  (no glob imports bring both into scope), but flagging it here in case a
  future PR wants to rename it for clarity.
