### PR TITLE
feat(replay): implement sandbox execution and hot-path state reconstruction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ toml = "0.8"
 base64 = "0.22"
 hex = "0.4.3"
 libc = "0.2"
+sha2 = "0.10"
 
 # Web Server (using built-in HTTP server)
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -34,6 +34,9 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
 
+# Cryptography
+sha2 = { workspace = true }
+
 # WASM Processing
 wasmparser = { workspace = true }
 

--- a/crates/core/src/replay/mod.rs
+++ b/crates/core/src/replay/mod.rs
@@ -4,9 +4,11 @@ pub mod sandbox;
 pub mod state;
 pub mod trace;
 
+use crate::decode::auth::scval_to_readable_string;
+use crate::decode::walk_diagnostic_events;
 use crate::error::GratResult;
 use crate::types::config::NetworkConfig;
-use crate::types::trace::ExecutionTrace;
+use crate::types::trace::{DiagnosticEvent, ExecutionTrace};
 
 pub async fn replay_transaction(
     tx_hash: &str,
@@ -22,6 +24,20 @@ pub async fn replay_transaction(
 
     let profile = profiler::generate_profile(&raw_trace, &state_diff)?;
 
+    let diagnostic_events = walk_diagnostic_events(&raw_trace.diagnostic_events)
+        .into_iter()
+        .enumerate()
+        .map(|(timeline_position, event)| DiagnosticEvent {
+            event_type: event.kind.to_string(),
+            topics: event.topics.iter().map(scval_to_readable_string).collect(),
+            data: std::collections::HashMap::from([(
+                "value".to_string(),
+                scval_to_readable_string(&event.data),
+            )]),
+            timeline_position,
+        })
+        .collect();
+
     Ok(ExecutionTrace {
         tx_hash: tx_hash.to_string(),
         ledger_sequence: ledger_state.ledger_sequence,
@@ -29,6 +45,6 @@ pub async fn replay_transaction(
         invocations: trace_tree,
         state_diff,
         resource_profile: profile,
-        diagnostic_events: Vec::new(),
+        diagnostic_events,
     })
 }

--- a/crates/core/src/replay/sandbox.rs
+++ b/crates/core/src/replay/sandbox.rs
@@ -1,5 +1,13 @@
 use crate::error::{GratError, GratResult};
-use crate::replay::state::LedgerState;
+use crate::replay::state::{encode_xdr, LedgerState};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use sha2::{Digest, Sha256};
+use soroban_env_host::budget::Budget;
+use soroban_env_host::e2e_invoke::invoke_host_function_with_trace_hook;
+use soroban_env_host::{LedgerInfo, TraceEvent as HostTraceEvent, TraceHook};
+use std::cell::RefCell;
+use std::rc::Rc;
+use stellar_xdr::curr::{DiagnosticEvent, Hash as XdrHash, TtlEntry};
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct TraceEvent {
@@ -42,16 +50,245 @@ pub struct SandboxResult {
     pub total_cpu: u64,
 
     pub total_memory: u64,
+
+    pub diagnostic_events: Vec<DiagnosticEvent>,
 }
 
-pub async fn execute_with_tracing(
-    _state: &LedgerState,
-    _tx_hash: &str,
-) -> GratResult<SandboxResult> {
-    tracing::info!("Sandbox execution with tracing — not yet implemented");
+/// Generous fixed ceiling for the replay memory budget. Unlike the CPU
+/// instruction limit (which is taken directly from the transaction's own
+/// recorded `SorobanResources`, so it matches what actually ran at
+/// consensus), the network's exact per-transaction memory ceiling isn't
+/// fetched here — this only needs to sit comfortably above real usage so
+/// tracing is never cut short by an artificial memory limit.
+const MEM_BYTES_CEILING: u64 = 500 * 1024 * 1024;
 
-    Err(GratError::ReplayError(
-        "Sandbox execution not yet implemented. Requires soroban-env-host instrumentation."
-            .to_string(),
-    ))
+pub async fn execute_with_tracing(state: &LedgerState, tx_hash: &str) -> GratResult<SandboxResult> {
+    let inv = &state.invocation;
+
+    let budget = Budget::try_from_configs(
+        inv.cpu_instructions_limit.max(1),
+        MEM_BYTES_CEILING,
+        inv.cpu_cost_params.clone(),
+        inv.mem_cost_params.clone(),
+    )
+    .map_err(|e| GratError::ReplayError(format!("failed to build execution budget: {e}")))?;
+
+    let ledger_info = LedgerInfo {
+        protocol_version: inv.protocol_version,
+        sequence_number: state.ledger_sequence,
+        timestamp: inv.timestamp,
+        network_id: inv.network_id,
+        base_reserve: inv.base_reserve,
+        min_temp_entry_ttl: inv.min_temp_entry_ttl,
+        min_persistent_entry_ttl: inv.min_persistent_entry_ttl,
+        max_entry_ttl: inv.max_entry_ttl,
+    };
+
+    let mut encoded_ledger_entries: Vec<Vec<u8>> = Vec::new();
+    let mut encoded_ttl_entries: Vec<Vec<u8>> = Vec::new();
+    for key_b64 in inv.read_only_keys.iter().chain(inv.read_write_keys.iter()) {
+        let Some(entry_bytes) = state.entries.get(key_b64) else {
+            // Footprint key that doesn't exist yet (e.g. storage the
+            // contract is about to create for the first time).
+            continue;
+        };
+        encoded_ledger_entries.push(entry_bytes.clone());
+        encoded_ttl_entries.push(match inv.ttl_by_key.get(key_b64) {
+            Some(live_until) => encode_ttl_entry(key_b64, *live_until)?,
+            None => Vec::new(),
+        });
+    }
+
+    let seed: [u8; 32] = Sha256::digest(tx_hash.as_bytes()).into();
+
+    let events: Rc<RefCell<Vec<TraceEvent>>> = Rc::new(RefCell::new(Vec::new()));
+    let events_for_hook = Rc::clone(&events);
+    let budget_for_hook = budget.clone();
+    let start_time = std::time::Instant::now();
+
+    let trace_hook: TraceHook = Rc::new(move |_host, event| {
+        let cpu = budget_for_hook.get_cpu_insns_consumed().unwrap_or(0);
+        let mem = budget_for_hook.get_mem_bytes_consumed().unwrap_or(0);
+        let timestamp_us = start_time.elapsed().as_micros() as u64;
+
+        let (event_type, mut data) = classify_trace_event(&event);
+        if let serde_json::Value::Object(ref mut map) = data {
+            map.insert("cpu_insns".to_string(), serde_json::json!(cpu));
+            map.insert("mem_bytes".to_string(), serde_json::json!(mem));
+        }
+
+        events_for_hook.borrow_mut().push(TraceEvent {
+            event_type,
+            timestamp_us,
+            data,
+        });
+        Ok(())
+    });
+
+    let mut diagnostic_events: Vec<DiagnosticEvent> = Vec::new();
+
+    let invoke_result = invoke_host_function_with_trace_hook(
+        &budget,
+        true,
+        inv.host_function_xdr.clone(),
+        inv.resources_xdr.clone(),
+        inv.source_account_xdr.clone(),
+        inv.auth_entries_xdr.clone().into_iter(),
+        ledger_info,
+        encoded_ledger_entries.into_iter(),
+        encoded_ttl_entries.into_iter(),
+        seed.to_vec(),
+        &mut diagnostic_events,
+        Some(trace_hook),
+    )
+    .map_err(|e| {
+        GratError::ReplayError(format!(
+            "sandbox execution setup failed for transaction {tx_hash}: {e}"
+        ))
+    })?;
+
+    if !diagnostic_events.is_empty() {
+        tracing::debug!(
+            tx_hash,
+            count = diagnostic_events.len(),
+            "captured diagnostic events during sandbox execution"
+        );
+    }
+
+    let success = invoke_result.encoded_invoke_result.is_ok();
+    if let Err(e) = &invoke_result.encoded_invoke_result {
+        tracing::info!(tx_hash, error = %e, "sandboxed invocation did not succeed");
+    }
+
+    let mut final_state = state.entries.clone();
+    for change in &invoke_result.ledger_changes {
+        if change.read_only {
+            continue;
+        }
+        let key_b64 = STANDARD.encode(&change.encoded_key);
+        match &change.encoded_new_value {
+            Some(new_value) => {
+                final_state.insert(key_b64, new_value.clone());
+            }
+            None => {
+                final_state.remove(&key_b64);
+            }
+        }
+    }
+
+    let total_cpu = budget.get_cpu_insns_consumed().unwrap_or(0);
+    let total_memory = budget.get_mem_bytes_consumed().unwrap_or(0);
+
+    let events = match Rc::try_unwrap(events) {
+        Ok(cell) => cell.into_inner(),
+        Err(shared) => shared.borrow().clone(),
+    };
+
+    Ok(SandboxResult {
+        success,
+        events,
+        final_state,
+        total_cpu,
+        total_memory,
+        diagnostic_events,
+    })
+}
+
+fn encode_ttl_entry(key_b64: &str, live_until_ledger_seq: u32) -> GratResult<Vec<u8>> {
+    let key_bytes = STANDARD
+        .decode(key_b64)
+        .map_err(|e| GratError::XdrDecodingFailed {
+            type_name: "LedgerKey",
+            reason: format!("invalid base64: {e}"),
+        })?;
+    let key_hash: [u8; 32] = Sha256::digest(&key_bytes).into();
+    let ttl_entry = TtlEntry {
+        key_hash: XdrHash(key_hash),
+        live_until_ledger_seq,
+    };
+    encode_xdr(&ttl_entry, "TtlEntry")
+}
+
+/// Classifies one host trace event and renders it into our own event schema.
+///
+/// The host's `Context`/`Frame` types backing `PushCtx`/`PopCtx` aren't public
+/// outside `soroban-env-host`, so the contract id and function name for those
+/// two variants are recovered by best-effort parsing of the host's own
+/// `Display` rendering (of the form `push VM:<id>:<fn>(...)` /
+/// `pop VM:<id>:<fn> -> Ok(...)`) rather than field access. `EnvCall`/`EnvRet`
+/// carry their function name directly and don't need this.
+fn classify_trace_event(event: &HostTraceEvent<'_>) -> (TraceEventType, serde_json::Value) {
+    match event {
+        HostTraceEvent::Begin => (
+            TraceEventType::BudgetCheckpoint,
+            serde_json::json!({ "phase": "begin" }),
+        ),
+        HostTraceEvent::End => (
+            TraceEventType::BudgetCheckpoint,
+            serde_json::json!({ "phase": "end" }),
+        ),
+        HostTraceEvent::PushCtx(..) => {
+            let detail = format!("{event}");
+            let (contract_id, function) = parse_frame_label(&detail, "push ", "(");
+            (
+                TraceEventType::InvocationStart,
+                serde_json::json!({
+                    "contract_id": contract_id,
+                    "function": function,
+                    "detail": detail,
+                }),
+            )
+        }
+        HostTraceEvent::PopCtx(.., result) => {
+            let detail = format!("{event}");
+            let (contract_id, function) = parse_frame_label(&detail, "pop ", " ->");
+            (
+                TraceEventType::InvocationEnd,
+                serde_json::json!({
+                    "contract_id": contract_id,
+                    "function": function,
+                    "is_error": result.is_err(),
+                    "detail": detail,
+                }),
+            )
+        }
+        HostTraceEvent::EnvCall(name, _args) => (
+            TraceEventType::HostFunctionCall,
+            serde_json::json!({
+                "function": name,
+                "detail": format!("{event}"),
+            }),
+        ),
+        HostTraceEvent::EnvRet(name, result) => (
+            TraceEventType::HostFunctionReturn,
+            serde_json::json!({
+                "function": name,
+                "is_error": result.is_err(),
+                "detail": format!("{event}"),
+            }),
+        ),
+    }
+}
+
+fn parse_frame_label(
+    detail: &str,
+    prefix: &str,
+    end_marker: &str,
+) -> (Option<String>, Option<String>) {
+    let Some(rest) = detail.strip_prefix(prefix) else {
+        return (None, None);
+    };
+    let Some(end) = rest.find(end_marker) else {
+        return (None, None);
+    };
+    let label = &rest[..end];
+    let mut parts = label.splitn(3, ':');
+    let ty = parts.next().unwrap_or_default();
+    let id = parts.next().unwrap_or_default();
+    let function = parts.next().filter(|f| !f.is_empty()).map(str::to_string);
+
+    if ty.is_empty() && id.is_empty() {
+        return (None, function);
+    }
+    (Some(format!("{ty}:{id}")), function)
 }

--- a/crates/core/src/replay/state.rs
+++ b/crates/core/src/replay/state.rs
@@ -1,14 +1,63 @@
 use crate::error::{GratError, GratResult};
 use crate::types::config::NetworkConfig;
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use stellar_xdr::curr::{
+    AccountId, ConfigSettingEntry, ConfigSettingId, ContractCostParams, FeeBumpTransactionInnerTx,
+    InvokeHostFunctionOp, LedgerEntry, LedgerEntryData, LedgerKey, LedgerKeyConfigSetting, Limits,
+    MuxedAccount, OperationBody, PublicKey, ReadXdr, StateArchivalSettings, Transaction,
+    TransactionEnvelope, TransactionExt, TransactionV1Envelope, WriteXdr,
+};
+
+/// Everything the sandbox needs, beyond raw ledger entries, to actually invoke
+/// the transaction's host function through `soroban-env-host`.
+///
+/// All XDR payloads are pre-encoded (rather than kept as typed values) because
+/// that's the shape `soroban_env_host::e2e_invoke::invoke_host_function_with_trace_hook`
+/// consumes directly — encoding here means the sandbox never has to re-derive it.
+#[derive(Debug, Clone)]
+pub struct InvocationInput {
+    pub host_function_xdr: Vec<u8>,
+    pub resources_xdr: Vec<u8>,
+    pub source_account_xdr: Vec<u8>,
+    pub auth_entries_xdr: Vec<Vec<u8>>,
+
+    /// base64(LedgerKey XDR) for every key in the transaction's declared footprint.
+    pub read_only_keys: Vec<String>,
+    pub read_write_keys: Vec<String>,
+
+    /// base64(LedgerKey XDR) -> live-until ledger, for footprint keys that carry a TTL.
+    pub ttl_by_key: HashMap<String, u32>,
+
+    pub cpu_cost_params: ContractCostParams,
+    pub mem_cost_params: ContractCostParams,
+
+    pub network_id: [u8; 32],
+    pub protocol_version: u32,
+    pub timestamp: u64,
+    pub base_reserve: u32,
+    pub min_temp_entry_ttl: u32,
+    pub min_persistent_entry_ttl: u32,
+    pub max_entry_ttl: u32,
+
+    /// The instruction budget the transaction itself was allowed to consume at
+    /// consensus time; reused as the replay CPU ceiling so a successful mainnet
+    /// transaction never gets cut short here.
+    pub cpu_instructions_limit: u64,
+}
 
 #[derive(Debug, Clone)]
 pub struct LedgerState {
     pub ledger_sequence: u32,
 
+    /// base64(LedgerKey XDR) -> raw LedgerEntry XDR bytes, for every footprint
+    /// key that currently exists in the ledger.
     pub entries: HashMap<String, Vec<u8>>,
 
     pub reconstruction_path: ReconstructionPath,
+
+    pub invocation: InvocationInput,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -19,6 +68,11 @@ pub enum ReconstructionPath {
 }
 
 const HOT_PATH_THRESHOLD: u32 = 50_000;
+
+/// Stellar's network base reserve (in stroops) has been unchanged since genesis
+/// on every public network; it isn't exposed via a soroban-rpc ledger-entry
+/// lookup, so it's a documented constant rather than a network round-trip.
+const BASE_RESERVE_STROOPS: u32 = 5_000_000;
 
 pub async fn reconstruct_state(tx_hash: &str, network: &NetworkConfig) -> GratResult<LedgerState> {
     let rpc = crate::rpc::SorobanRpcClient::new(network);
@@ -31,28 +85,217 @@ pub async fn reconstruct_state(tx_hash: &str, network: &NetworkConfig) -> GratRe
     let latest: serde_json::Value = rpc.get_latest_ledger().await?;
     let latest_ledger = latest
         .get("sequence")
-        .and_then(|s: &serde_json::Value| s.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .unwrap_or(0) as u32;
+    let protocol_version = parse_protocol_version(latest.get("protocolVersion"));
 
     let age = latest_ledger.saturating_sub(tx_ledger);
 
     if age <= HOT_PATH_THRESHOLD {
         tracing::info!("Using hot path (RPC) for ledger {tx_ledger} (age: {age} ledgers)");
-        reconstruct_hot_path(tx_ledger, &rpc).await
+        reconstruct_hot_path(tx_ledger, protocol_version, &tx_data, &rpc, network).await
     } else {
         tracing::info!("Using cold path (archive) for ledger {tx_ledger} (age: {age} ledgers)");
         reconstruct_cold_path(tx_ledger, network).await
     }
 }
 
+fn parse_protocol_version(value: Option<&serde_json::Value>) -> u32 {
+    value
+        .and_then(|v| {
+            v.as_u64()
+                .or_else(|| v.as_str().and_then(|s| s.parse::<u64>().ok()))
+        })
+        .unwrap_or(0) as u32
+}
+
 async fn reconstruct_hot_path(
     ledger_sequence: u32,
-    _rpc: &crate::rpc::SorobanRpcClient,
+    protocol_version: u32,
+    tx_data: &crate::rpc::client::GetTransactionResponse,
+    rpc: &crate::rpc::SorobanRpcClient,
+    network: &NetworkConfig,
 ) -> GratResult<LedgerState> {
+    let envelope_xdr = tx_data.envelope_xdr.as_deref().ok_or_else(|| {
+        GratError::ReplayError("Transaction envelope XDR is missing from getTransaction".into())
+    })?;
+    let envelope_bytes =
+        STANDARD
+            .decode(envelope_xdr)
+            .map_err(|e| GratError::XdrDecodingFailed {
+                type_name: "TransactionEnvelope",
+                reason: format!("invalid base64: {e}"),
+            })?;
+    let envelope = TransactionEnvelope::from_xdr(&envelope_bytes, Limits::none()).map_err(|e| {
+        GratError::XdrDecodingFailed {
+            type_name: "TransactionEnvelope",
+            reason: e.to_string(),
+        }
+    })?;
+
+    let tx = extract_transaction(&envelope)?;
+    let invoke_op = extract_invoke_host_function_op(tx)?;
+
+    let soroban_data = match &tx.ext {
+        TransactionExt::V1(data) => data,
+        TransactionExt::V0 => {
+            return Err(GratError::ReplayError(
+                "Transaction has no Soroban resource data attached".to_string(),
+            ))
+        }
+    };
+
+    let read_only_keys = encode_keys(soroban_data.resources.footprint.read_only.iter())?;
+    let read_write_keys = encode_keys(soroban_data.resources.footprint.read_write.iter())?;
+
+    let cpu_cost_key = config_setting_key(ConfigSettingId::ContractCostParamsCpuInstructions);
+    let mem_cost_key = config_setting_key(ConfigSettingId::ContractCostParamsMemoryBytes);
+    let archival_key = config_setting_key(ConfigSettingId::StateArchival);
+    let cpu_cost_key_b64 = encode_key(&cpu_cost_key)?;
+    let mem_cost_key_b64 = encode_key(&mem_cost_key)?;
+    let archival_key_b64 = encode_key(&archival_key)?;
+
+    let mut all_keys = read_only_keys.clone();
+    all_keys.extend(read_write_keys.iter().cloned());
+    all_keys.push(cpu_cost_key_b64.clone());
+    all_keys.push(mem_cost_key_b64.clone());
+    all_keys.push(archival_key_b64.clone());
+
+    let response = rpc.get_ledger_entries(&all_keys).await?;
+    let entries_json = response
+        .get("entries")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| {
+            GratError::ReplayError("getLedgerEntries response is missing an entries array".into())
+        })?;
+
+    let mut entries: HashMap<String, Vec<u8>> = HashMap::new();
+    let mut ttl_by_key: HashMap<String, u32> = HashMap::new();
+    let mut cpu_cost_params: Option<ContractCostParams> = None;
+    let mut mem_cost_params: Option<ContractCostParams> = None;
+    let mut archival_settings: Option<StateArchivalSettings> = None;
+
+    for entry_json in entries_json {
+        let key_b64 = entry_json.get("key").and_then(serde_json::Value::as_str);
+        let xdr_b64 = entry_json
+            .get("xdr")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                GratError::ReplayError("getLedgerEntries entry is missing its xdr field".into())
+            })?;
+        let entry_bytes = STANDARD
+            .decode(xdr_b64)
+            .map_err(|e| GratError::XdrDecodingFailed {
+                type_name: "LedgerEntry",
+                reason: format!("invalid base64: {e}"),
+            })?;
+
+        let key_b64 = key_b64.ok_or_else(|| {
+            GratError::ReplayError(
+                "getLedgerEntries entry is missing its key field — RPC node is too old to \
+                 support replay"
+                    .to_string(),
+            )
+        })?;
+
+        let ledger_entry = LedgerEntry::from_xdr(&entry_bytes, Limits::none()).map_err(|e| {
+            GratError::XdrDecodingFailed {
+                type_name: "LedgerEntry",
+                reason: e.to_string(),
+            }
+        })?;
+
+        if key_b64 == cpu_cost_key_b64 {
+            if let LedgerEntryData::ConfigSetting(
+                ConfigSettingEntry::ContractCostParamsCpuInstructions(p),
+            ) = ledger_entry.data
+            {
+                cpu_cost_params = Some(p);
+            }
+        } else if key_b64 == mem_cost_key_b64 {
+            if let LedgerEntryData::ConfigSetting(
+                ConfigSettingEntry::ContractCostParamsMemoryBytes(p),
+            ) = ledger_entry.data
+            {
+                mem_cost_params = Some(p);
+            }
+        } else if key_b64 == archival_key_b64 {
+            if let LedgerEntryData::ConfigSetting(ConfigSettingEntry::StateArchival(s)) =
+                ledger_entry.data
+            {
+                archival_settings = Some(s);
+            }
+        } else {
+            if let Some(live_until) = entry_json
+                .get("liveUntilLedgerSeq")
+                .and_then(serde_json::Value::as_u64)
+            {
+                ttl_by_key.insert(key_b64.to_string(), live_until as u32);
+            }
+            entries.insert(key_b64.to_string(), entry_bytes);
+        }
+    }
+
+    let cpu_cost_params = cpu_cost_params.ok_or_else(|| {
+        GratError::ReplayError(
+            "Network CPU cost parameters are unavailable — cannot build an execution budget"
+                .to_string(),
+        )
+    })?;
+    let mem_cost_params = mem_cost_params.ok_or_else(|| {
+        GratError::ReplayError(
+            "Network memory cost parameters are unavailable — cannot build an execution budget"
+                .to_string(),
+        )
+    })?;
+    let archival_settings = archival_settings.ok_or_else(|| {
+        GratError::ReplayError(
+            "Network state-archival settings are unavailable — cannot determine entry TTLs"
+                .to_string(),
+        )
+    })?;
+
+    let source_account = muxed_account_to_account_id(&tx.source_account);
+    let host_function_xdr = encode_xdr(&invoke_op.host_function, "HostFunction")?;
+    let resources_xdr = encode_xdr(&soroban_data.resources, "SorobanResources")?;
+    let source_account_xdr = encode_xdr(&source_account, "AccountId")?;
+    let auth_entries_xdr = invoke_op
+        .auth
+        .iter()
+        .map(|a| encode_xdr(a, "SorobanAuthorizationEntry"))
+        .collect::<GratResult<Vec<_>>>()?;
+
+    let network_id: [u8; 32] = Sha256::digest(network.network_passphrase.as_bytes()).into();
+
+    // The exact close time of the historical ledger isn't exposed by
+    // getTransaction; the latest ledger's close time is used as a documented
+    // approximation (only observable difference for time-sensitive contract
+    // logic within the hot-path recency window).
+    let timestamp = tx_data.latest_ledger_close_time.unwrap_or(0);
+
     Ok(LedgerState {
         ledger_sequence,
-        entries: HashMap::new(),
+        entries,
         reconstruction_path: ReconstructionPath::HotPath,
+        invocation: InvocationInput {
+            host_function_xdr,
+            resources_xdr,
+            source_account_xdr,
+            auth_entries_xdr,
+            read_only_keys,
+            read_write_keys,
+            ttl_by_key,
+            cpu_cost_params,
+            mem_cost_params,
+            network_id,
+            protocol_version,
+            timestamp,
+            base_reserve: BASE_RESERVE_STROOPS,
+            min_temp_entry_ttl: archival_settings.min_temporary_ttl,
+            min_persistent_entry_ttl: archival_settings.min_persistent_ttl,
+            max_entry_ttl: archival_settings.max_entry_ttl,
+            cpu_instructions_limit: u64::from(soroban_data.resources.instructions),
+        },
     })
 }
 
@@ -60,11 +303,62 @@ async fn reconstruct_cold_path(
     ledger_sequence: u32,
     _network: &NetworkConfig,
 ) -> GratResult<LedgerState> {
-    tracing::warn!("Cold path reconstruction is computationally heavy — this may take a while");
+    Err(GratError::ReplayError(format!(
+        "Cold-path (archived) ledger reconstruction for ledger {ledger_sequence} is not yet \
+         implemented — only transactions within the last {HOT_PATH_THRESHOLD} ledgers can be \
+         replayed"
+    )))
+}
 
-    Ok(LedgerState {
-        ledger_sequence,
-        entries: HashMap::new(),
-        reconstruction_path: ReconstructionPath::ColdPath,
-    })
+fn extract_transaction(envelope: &TransactionEnvelope) -> GratResult<&Transaction> {
+    match envelope {
+        TransactionEnvelope::Tx(TransactionV1Envelope { tx, .. }) => Ok(tx),
+        TransactionEnvelope::TxFeeBump(fb) => match &fb.tx.inner_tx {
+            FeeBumpTransactionInnerTx::Tx(TransactionV1Envelope { tx, .. }) => Ok(tx),
+        },
+        TransactionEnvelope::TxV0(_) => Err(GratError::ReplayError(
+            "Transaction envelope is a pre-Soroban V0 envelope and cannot invoke a host function"
+                .to_string(),
+        )),
+    }
+}
+
+fn extract_invoke_host_function_op(tx: &Transaction) -> GratResult<&InvokeHostFunctionOp> {
+    tx.operations
+        .iter()
+        .find_map(|op| match &op.body {
+            OperationBody::InvokeHostFunction(invoke) => Some(invoke),
+            _ => None,
+        })
+        .ok_or(GratError::NotSorobanTransaction)
+}
+
+fn muxed_account_to_account_id(account: &MuxedAccount) -> AccountId {
+    let ed25519 = match account {
+        MuxedAccount::Ed25519(key) => key.clone(),
+        MuxedAccount::MuxedEd25519(med) => med.ed25519.clone(),
+    };
+    AccountId(PublicKey::PublicKeyTypeEd25519(ed25519))
+}
+
+fn config_setting_key(config_setting_id: ConfigSettingId) -> LedgerKey {
+    LedgerKey::ConfigSetting(LedgerKeyConfigSetting { config_setting_id })
+}
+
+fn encode_key(key: &LedgerKey) -> GratResult<String> {
+    let bytes = encode_xdr(key, "LedgerKey")?;
+    Ok(STANDARD.encode(bytes))
+}
+
+fn encode_keys<'a>(keys: impl Iterator<Item = &'a LedgerKey>) -> GratResult<Vec<String>> {
+    keys.map(encode_key).collect()
+}
+
+pub(crate) fn encode_xdr<T: WriteXdr>(value: &T, type_name: &'static str) -> GratResult<Vec<u8>> {
+    value
+        .to_xdr(Limits::none())
+        .map_err(|e| GratError::XdrDecodingFailed {
+            type_name,
+            reason: e.to_string(),
+        })
 }


### PR DESCRIPTION
## Summary
- `reconstruct_hot_path` now decodes the transaction envelope, extracts the `InvokeHostFunctionOp`/footprint, and fetches ledger entries plus network cost/archival config settings via RPC to build a real `InvocationInput`, instead of returning an empty ledger state.
- `execute_with_tracing` builds a `soroban-env-host` `Budget` from that input and drives `invoke_host_function_with_trace_hook`, translating host trace events (`PushCtx`/`PopCtx`/`EnvCall`/`EnvRet`) into the crate's own `TraceEvent` schema and diffing ledger changes into `final_state` — replacing the stub that immediately logged "not yet implemented" and errored.
- Diagnostic events captured during sandbox execution are threaded through `replay_transaction` into `ExecutionTrace` instead of being discarded.
- Cold-path (archived ledger) reconstruction now returns an explicit "not yet implemented" error instead of silently returning empty state.

Fixes #391

## Test plan
- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo test --workspace` — 326 passed, 0 failed
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)