### PR TITLE
feat/add multi-operation transaction decoding

### DIFF
--- a/crates/core/src/decode/mod.rs
+++ b/crates/core/src/decode/mod.rs
@@ -14,6 +14,7 @@ pub mod fee_analyzer;
 pub mod function_call_decoder;
 pub mod host_error;
 pub mod mappings;
+/// Envelope-level decoding that emits one diagnostic report per operation.
 pub mod multi_op_decoder;
 pub mod report;
 pub mod resource_analyzer;

--- a/crates/core/src/decode/multi_op_decoder.rs
+++ b/crates/core/src/decode/multi_op_decoder.rs
@@ -1,27 +1,96 @@
-use crate::decode::host_error::classify_error;
-use crate::decode::report::build_report;
-use crate::error::GratResult;
+use crate::decode::function_call_decoder::FunctionCallDecoder;
+use crate::error::{GratError, GratResult};
 use crate::network::config::NetworkConfig;
 use crate::rpc::SorobanRpcClient;
-use crate::types::report::DiagnosticReport;
+use crate::types::report::{DiagnosticReport, Severity};
 use crate::xdr::codec::XdrCodec;
+use serde::Serialize;
+use serde_json::Value;
 use stellar_xdr::curr::{
-    ContractEvent, ContractEventBody, DiagnosticEvent, Operation, OperationBody, OperationResult,
-    OperationResultTr, TransactionEnvelope, TransactionMeta, TransactionResult,
-    TransactionResultResult, TransactionV1Envelope,
+    ContractEvent, ContractEventBody, DiagnosticEvent, FeeBumpTransactionInnerTx, HostFunction,
+    InnerTransactionResultResult, Operation, OperationBody, OperationResult, OperationResultTr,
+    ScAddress, ScVal, SorobanTransactionMeta, TransactionEnvelope, TransactionMeta,
+    TransactionResult, TransactionResultResult,
 };
-use stellar_xdr::curr::{FeeBumpTransactionInnerTx, ScVal};
 
-struct OperationResultInfo {
-    function_name: Option<String>,
-    arguments: Vec<String>,
-    return_value: Option<String>,
-    is_success: bool,
-    error_category: Option<String>,
-    error_name: Option<String>,
+pub struct MultiOpDecoder {
+    function_call_decoder: FunctionCallDecoder,
 }
 
-pub struct MultiOpDecoder;
+struct DecodedOperation {
+    // One report-facing representation per envelope operation.
+    operation_name: String,
+    display_name: String,
+    arguments: Vec<String>,
+    return_value: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct DecodedOperationResult {
+    success: bool,
+    attempted: bool,
+    category: String,
+    code: String,
+}
+
+fn decode_contract_call(
+    decoder: &FunctionCallDecoder,
+    args: &stellar_xdr::curr::InvokeContractArgs,
+    value: Option<&ScVal>,
+) -> DecodedOperation {
+    let call = decoder.decode(
+        &args.function_name.to_string(),
+        args.args.as_ref(),
+        None,
+        value,
+        None,
+    );
+    DecodedOperation {
+        operation_name: "InvokeHostFunction".into(),
+        display_name: call.function_name,
+        arguments: format_arguments(call.arguments),
+        return_value: call.formatted_return_value,
+    }
+}
+
+struct TransactionResultSet<'a> {
+    // Results stay aligned with the envelope by index.
+    operation_results: &'a [OperationResult],
+    transaction_failure: Option<&'static str>,
+    committed: bool,
+}
+
+fn format_arguments(values: Vec<crate::decode::DecodedArgument>) -> Vec<String> {
+    values.into_iter().map(format_argument).collect()
+}
+
+fn format_argument(value: crate::decode::DecodedArgument) -> String {
+    format!("{}: {}", value.name, value.formatted)
+}
+
+fn decode_operation_payload(
+    decoder: &FunctionCallDecoder,
+    operation: &Operation,
+    return_value: Option<&ScVal>,
+) -> DecodedOperation {
+    let OperationBody::InvokeHostFunction(invoke) = &operation.body else {
+        return DecodedOperation {
+            operation_name: operation.body.name().to_string(),
+            display_name: operation.body.name().to_string(),
+            arguments: extract_xdr_arguments(&operation.body),
+            return_value: return_value.map(format_scval),
+        };
+    };
+    match &invoke.host_function {
+        HostFunction::InvokeContract(args) => decode_contract_call(decoder, args, return_value),
+        function => DecodedOperation {
+            operation_name: operation.body.name().to_string(),
+            display_name: function.name().to_string(),
+            arguments: extract_xdr_arguments(&operation.body),
+            return_value: return_value.map(format_scval),
+        },
+    }
+}
 
 impl Default for MultiOpDecoder {
     fn default() -> Self {
@@ -30,476 +99,630 @@ impl Default for MultiOpDecoder {
 }
 
 impl MultiOpDecoder {
+    #[must_use]
     pub fn new() -> Self {
-        Self
+        Self {
+            function_call_decoder: FunctionCallDecoder::new(),
+        }
     }
 
-    #[allow(clippy::too_many_lines)]
-    pub fn decode_transaction(
-        &self,
-        tx_data: &serde_json::Value,
-    ) -> GratResult<Vec<DiagnosticReport>> {
-        let envelope_xdr = tx_data
-            .get("envelopeXdr")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| {
-                crate::error::GratError::Internal(
-                    "Missing envelopeXdr in transaction data".to_string(),
-                )
-            })?;
-
-        let envelope =
-            <TransactionEnvelope as XdrCodec>::from_xdr_base64(envelope_xdr).map_err(|e| {
-                crate::error::GratError::Internal(format!("Failed to decode envelope XDR: {e}"))
-            })?;
-
-        let num_ops = match &envelope {
-            TransactionEnvelope::Tx(TransactionV1Envelope { tx, .. }) => tx.operations.len(),
-            TransactionEnvelope::TxFeeBump(fb) => match &fb.tx.inner_tx {
-                FeeBumpTransactionInnerTx::Tx(TransactionV1Envelope { tx, .. }) => {
-                    tx.operations.len()
-                }
-            },
-            TransactionEnvelope::TxV0(_) => 1,
-        };
-
-        let result_xdr = tx_data
-            .get("resultXdr")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| {
-                crate::error::GratError::Internal(
-                    "Missing resultXdr in transaction data".to_string(),
-                )
-            })?;
-
-        let tx_result =
-            <TransactionResult as XdrCodec>::from_xdr_base64(result_xdr).map_err(|e| {
-                crate::error::GratError::Internal(format!("Failed to decode result XDR: {e}"))
-            })?;
-
-        let op_results = match tx_result.result {
-            TransactionResultResult::TxSuccess(ops) | TransactionResultResult::TxFailed(ops) => ops,
-            TransactionResultResult::TxFeeBumpInnerSuccess(_) => {
-                return Ok(vec![build_report(&classify_error(tx_data)?)
-                    .map_err(|e| crate::error::GratError::Internal(format!("{e}")))?])
-            }
-            _ => {
-                return Err(crate::error::GratError::NotSorobanTransaction);
-            }
-        };
-
-        let meta_xdr = tx_data
-            .get("resultMetaXdr")
-            .and_then(|v| v.as_str())
-            .map(|xdr| {
-                <TransactionMeta as XdrCodec>::from_xdr_base64(xdr).map_err(|e| {
-                    crate::error::GratError::Internal(format!("Failed to decode meta XDR: {e}"))
-                })
-            })
-            .transpose()?;
-
-        let soroban_meta = meta_xdr.and_then(|meta| match meta {
-            TransactionMeta::V3(v3) => v3.soroban_meta,
-            TransactionMeta::V0(_) | TransactionMeta::V1(_) | TransactionMeta::V2(_) => None,
-        });
-
-        let all_diagnostic_events = soroban_meta
-            .as_ref()
-            .map(|sm| sm.diagnostic_events.as_ref())
-            .map(|ev: &[DiagnosticEvent]| ev.to_vec())
-            .unwrap_or_default();
-
-        let all_contract_events = soroban_meta
-            .as_ref()
-            .map(|sm| sm.events.as_ref())
-            .map(|ev: &[ContractEvent]| ev.to_vec())
-            .unwrap_or_default();
-
-        let overall_resources =
+    /// Decode every operation in the envelope, preserving its original index.
+    pub fn decode_transaction(&self, tx_data: &Value) -> GratResult<Vec<DiagnosticReport>> {
+        let envelope = decode_required_xdr::<TransactionEnvelope>(tx_data, "envelopeXdr")?;
+        let tx_result = decode_required_xdr::<TransactionResult>(tx_data, "resultXdr")?;
+        let operations = envelope_operations(&envelope);
+        if operations.is_empty() {
+            return Ok(Vec::new());
+        }
+        let results = transaction_result_set(&tx_result.result);
+        let meta = decode_soroban_meta(tx_data)?;
+        let diagnostics = partition_diagnostic_events(
+            meta.as_ref()
+                .map(|m| m.diagnostic_events.as_ref())
+                .unwrap_or_default(),
+            operations,
+        );
+        let events = partition_contract_events(
+            meta.as_ref().map(|m| m.events.as_ref()).unwrap_or_default(),
+            operations,
+        );
+        let single_return = single_invoke_contract_index(operations)
+            .and_then(|index| meta.as_ref().map(|m| (index, &m.return_value)));
+        let resources =
             crate::decode::resource_analyzer::TransactionResultMeta::from_tx_data(tx_data);
-        let overall_resource_summary = crate::types::report::ResourceSummary {
-            cpu_instructions_used: overall_resources.resources_consumed.cpu_instructions,
-            cpu_instructions_limit: overall_resources.resources_allocated.cpu_instructions,
-            memory_bytes_used: overall_resources.resources_consumed.memory_bytes,
-            memory_bytes_limit: overall_resources.resources_allocated.memory_bytes,
-            read_bytes: overall_resources.resources_consumed.read_bytes,
-            read_bytes_limit: overall_resources.resources_allocated.read_bytes,
-            write_bytes: overall_resources.resources_consumed.write_bytes,
-        };
+        let summary = resource_summary(&resources);
+        let fee = crate::decode::fee_analyzer::analyze_fee_breakdown(tx_data);
 
-        let overall_fee = crate::decode::fee_analyzer::analyze_fee_breakdown(tx_data);
-
-        let operation_results = decode_operation_results(&envelope, &op_results, num_ops);
-
-        let operation_event_partitions =
-            partition_events_by_operation(&all_diagnostic_events, num_ops);
-
-        let operation_contract_partitions =
-            partition_contract_events_by_operation(&all_contract_events, num_ops);
-
-        let mut reports = Vec::new();
-
-        for (i, op_info) in operation_results.iter().enumerate().take(num_ops) {
-            let op_events = operation_event_partitions
-                .get(i)
-                .cloned()
-                .unwrap_or_default();
-            let op_contract_events = operation_contract_partitions
-                .get(i)
-                .cloned()
-                .unwrap_or_default();
-
-            let error_category = op_info
-                .error_category
-                .clone()
-                .unwrap_or_else(|| "unknown".to_string());
-            let error_name = op_info
-                .error_name
-                .clone()
-                .unwrap_or_else(|| "Unknown".to_string());
-
-            let mut report = if op_info.is_success {
-                DiagnosticReport::new(
-                    &error_category,
-                    0,
-                    &error_name,
-                    &format!("Operation {} succeeded", i + 1),
-                )
-            } else {
-                DiagnosticReport::new(
-                    &error_category,
-                    0,
-                    &error_name,
-                    &format!("Operation {} failed", i + 1),
-                )
-            };
-
-            report.transaction_context = Some(crate::types::report::TransactionContext {
-                tx_hash: tx_data
-                    .get("hash")
-                    .and_then(|h| h.as_str())
-                    .unwrap_or("unknown")
-                    .to_string(),
-                ledger_sequence: tx_data
-                    .get("ledger")
-                    .and_then(serde_json::Value::as_u64)
-                    .unwrap_or(0) as u32,
-                operation_count: Some(num_ops),
-                operation_index: Some(i),
-                function_name: op_info.function_name.clone(),
-                arguments: op_info.arguments.clone(),
-                return_value: op_info.return_value.clone(),
-                fee: overall_fee.clone(),
-                resources: overall_resource_summary.clone(),
-            });
-
-            if !op_events.is_empty() {
-                let op_events_xdr: Vec<String> = op_events
-                    .iter()
-                    .filter_map(|e| XdrCodec::to_xdr_base64(e).ok())
-                    .collect();
-
-                let enriched = serde_json::json!({
-                    "diagnosticEventsXdr": op_events_xdr,
-                    "hash": tx_data.get("hash"),
-                    "ledger": tx_data.get("ledger"),
+        operations
+            .iter()
+            .enumerate()
+            .map(|(index, operation)| {
+                let diagnostics = diagnostics
+                    .get(index)
+                    .map(Vec::as_slice)
+                    .unwrap_or_default();
+                let return_value = return_value_from_events(diagnostics).or_else(|| {
+                    single_return
+                        .and_then(|(return_index, value)| (return_index == index).then_some(value))
                 });
-                enrich_diagnostic_report(&mut report, &enriched).ok();
-            }
+                Ok(build_operation_report(
+                    tx_data,
+                    operations.len(),
+                    index,
+                    operation,
+                    self.decode_operation(operation, return_value),
+                    decode_operation_result(
+                        operation,
+                        results.operation_results.get(index),
+                        results.transaction_failure,
+                    ),
+                    results.committed,
+                    diagnostics,
+                    events.get(index).map(Vec::as_slice).unwrap_or_default(),
+                    &resources,
+                    fee.clone(),
+                    summary.clone(),
+                ))
+            })
+            .collect()
+    }
+}
 
-            let resource_json = serde_json::json!({
-                "diagnosticEvents": overall_resources.is_budget_error.then(|| {
-                    serde_json::json!({"type":"budget","data":{"category":"cpu","used":overall_resources.resources_consumed.cpu_instructions,"limit":overall_resources.resources_allocated.cpu_instructions}})
-                }).into_iter().collect::<Vec<_>>(),
-                "resourcesAllocated": serde_json::json!({
-                    "cpuInstructions": overall_resources.resources_allocated.cpu_instructions,
-                    "memoryBytes": overall_resources.resources_allocated.memory_bytes,
-                    "readBytes": overall_resources.resources_allocated.read_bytes,
-                    "writeBytes": overall_resources.resources_allocated.write_bytes,
-                }),
-                "resourcesConsumed": serde_json::json!({
-                    "cpuInstructions": overall_resources.resources_consumed.cpu_instructions,
-                    "memoryBytes": overall_resources.resources_consumed.memory_bytes,
-                    "readBytes": overall_resources.resources_consumed.read_bytes,
-                    "writeBytes": overall_resources.resources_consumed.write_bytes,
-                }),
-                "status": if op_info.is_success { "SUCCESS" } else { "FAILED" },
-            });
-            enrich_resource_report(&mut report, &resource_json).ok();
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stellar_xdr::curr::{InflationResult, VecM};
 
-            report.cross_contract_attribution = if op_contract_events.is_empty() {
-                None
-            } else {
-                Some(crate::types::report::FailureAttribution {
-                    contract_address: op_contract_events
-                        .iter()
-                        .find_map(|e| {
-                            e.contract_id.as_ref().map(|h| {
-                                h.0.iter().fold(String::new(), |mut acc, b| {
-                                    let _ = std::fmt::Write::write_fmt(
-                                        &mut acc,
-                                        format_args!("{b:02x}"),
-                                    );
-                                    acc
-                                })
-                            })
-                        })
-                        .unwrap_or_default(),
-                    function_name: op_info.function_name.clone(),
-                    call_depth: 0,
-                    origin_description: format!("Operation {}", i + 1),
-                })
-            };
-
-            reports.push(report);
+    fn operation(body: OperationBody) -> Operation {
+        Operation {
+            source_account: None,
+            body,
         }
+    }
 
-        Ok(reports)
+    #[test]
+    fn classic_success_is_not_reported_as_non_invoke_failure() {
+        let operation = operation(OperationBody::Inflation);
+        let result = OperationResult::OpInner(OperationResultTr::Inflation(
+            InflationResult::Success(VecM::default()),
+        ));
+        let decoded = decode_operation_result(&operation, Some(&result), None);
+        assert!(decoded.success);
+        assert!(decoded.attempted);
+        assert_eq!(decoded.category, "ClassicStellar");
+        assert_eq!(decoded.code, "Success");
+    }
+
+    #[test]
+    fn missing_result_is_not_fabricated_as_success() {
+        let operation = operation(OperationBody::Inflation);
+        let decoded = decode_operation_result(&operation, None, Some("TxBadSeq"));
+        assert!(!decoded.success);
+        assert!(!decoded.attempted);
+        assert_eq!(decoded.code, "TxBadSeq");
+    }
+
+    #[test]
+    fn result_type_must_match_envelope_operation() {
+        let operation = operation(OperationBody::Inflation);
+        let result = OperationResult::OpInner(OperationResultTr::InvokeHostFunction(
+            stellar_xdr::curr::InvokeHostFunctionResult::Trapped,
+        ));
+        let decoded = decode_operation_result(&operation, Some(&result), Some("TxFailed"));
+        assert!(!decoded.success);
+        assert_eq!(decoded.category, "Xdr");
+        assert_eq!(decoded.code, "OperationResultTypeMismatch");
     }
 }
 
-fn decode_operation_results(
-    envelope: &TransactionEnvelope,
-    op_results: &[OperationResult],
-    num_ops: usize,
-) -> Vec<OperationResultInfo> {
-    let mut results = Vec::with_capacity(num_ops);
-
-    for i in 0..num_ops {
-        let op = get_operation(envelope, i);
-        let op_result = op_results.get(i).cloned().unwrap_or({
-            OperationResult::OpInner(OperationResultTr::InvokeHostFunction(
-                stellar_xdr::curr::InvokeHostFunctionResult::Success(stellar_xdr::curr::Hash(
-                    [0; 32],
-                )),
-            ))
-        });
-
-        // Extract function details safely
-        let (fname, args) = op.as_ref().map_or((None, vec![]), |o| {
-            if let OperationBody::InvokeHostFunction(invoke) = &o.body {
-                if let stellar_xdr::curr::HostFunction::InvokeContract(invoke_args) =
-                    &invoke.host_function
-                {
-                    let f = invoke_args.function_name.to_string();
-                    let a: Vec<String> = invoke_args
-                        .args
-                        .iter()
-                        .map(|arg| format!("{arg:?}"))
-                        .collect();
-                    return (Some(f), a);
-                }
-            }
-            (None, vec![])
-        });
-
-        let info = match &op_result {
-            OperationResult::OpInner(OperationResultTr::InvokeHostFunction(inv_result)) => {
-                match inv_result {
-                    stellar_xdr::curr::InvokeHostFunctionResult::Success(_hash) => {
-                        OperationResultInfo {
-                            function_name: fname,
-                            arguments: args,
-                            return_value: None,
-                            is_success: true,
-                            error_category: None,
-                            error_name: None,
-                        }
-                    }
-                    stellar_xdr::curr::InvokeHostFunctionResult::Trapped => OperationResultInfo {
-                        function_name: fname,
-                        arguments: args,
-                        return_value: None,
-                        is_success: false,
-                        error_category: Some("Contract".to_string()),
-                        error_name: Some("HostError".to_string()),
-                    },
-                    stellar_xdr::curr::InvokeHostFunctionResult::ResourceLimitExceeded => {
-                        OperationResultInfo {
-                            function_name: fname,
-                            arguments: args,
-                            return_value: None,
-                            is_success: false,
-                            error_category: Some("Budget".to_string()),
-                            error_name: Some("HostError".to_string()),
-                        }
-                    }
-                    stellar_xdr::curr::InvokeHostFunctionResult::EntryArchived => {
-                        OperationResultInfo {
-                            function_name: fname,
-                            arguments: args,
-                            return_value: None,
-                            is_success: false,
-                            error_category: Some("Storage".to_string()),
-                            error_name: Some("HostError".to_string()),
-                        }
-                    }
-                    stellar_xdr::curr::InvokeHostFunctionResult::Malformed
-                    | stellar_xdr::curr::InvokeHostFunctionResult::InsufficientRefundableFee => {
-                        OperationResultInfo {
-                            function_name: fname,
-                            arguments: args,
-                            return_value: None,
-                            is_success: false,
-                            error_category: Some("Context".to_string()),
-                            error_name: Some("HostError".to_string()),
-                        }
-                    }
-                }
-            }
-            _ => OperationResultInfo {
-                function_name: if fname.is_none() || fname.as_deref() == Some("") {
-                    None
-                } else {
-                    fname
-                },
-                arguments: args,
-                return_value: None,
-                is_success: false,
-                error_category: Some("Unknown".to_string()),
-                error_name: Some("NonInvokeHostFunctionOperation".to_string()),
-            },
-        };
-
-        results.push(info);
-    }
-
-    results
+fn decode_required_xdr<T: XdrCodec>(tx_data: &Value, field: &'static str) -> GratResult<T> {
+    let value = tx_data
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| GratError::Internal(format!("Missing {field} in transaction data")))?;
+    T::from_xdr_base64(value)
+        .map_err(|error| GratError::Internal(format!("Failed to decode {field}: {error}")))
 }
 
-fn get_operation(envelope: &TransactionEnvelope, index: usize) -> Option<Operation> {
+fn envelope_operations(envelope: &TransactionEnvelope) -> &[Operation] {
     match envelope {
-        TransactionEnvelope::Tx(TransactionV1Envelope { tx, .. }) => {
-            tx.operations.get(index).cloned()
-        }
-        TransactionEnvelope::TxFeeBump(fb) => match &fb.tx.inner_tx {
-            FeeBumpTransactionInnerTx::Tx(TransactionV1Envelope { tx, .. }) => {
-                tx.operations.get(index).cloned()
-            }
+        TransactionEnvelope::TxV0(envelope) => envelope.tx.operations.as_ref(),
+        TransactionEnvelope::Tx(envelope) => envelope.tx.operations.as_ref(),
+        TransactionEnvelope::TxFeeBump(envelope) => match &envelope.tx.inner_tx {
+            FeeBumpTransactionInnerTx::Tx(envelope) => envelope.tx.operations.as_ref(),
         },
-        TransactionEnvelope::TxV0(_) => None,
     }
 }
 
-fn partition_events_by_operation(
-    diagnostic_events: &[DiagnosticEvent],
-    num_operations: usize,
+fn transaction_result_set(result: &TransactionResultResult) -> TransactionResultSet<'_> {
+    match result {
+        TransactionResultResult::TxSuccess(results) => TransactionResultSet {
+            operation_results: results.as_ref(),
+            transaction_failure: None,
+            committed: true,
+        },
+        TransactionResultResult::TxFailed(results) => TransactionResultSet {
+            operation_results: results.as_ref(),
+            transaction_failure: Some("TxFailed"),
+            committed: false,
+        },
+        TransactionResultResult::TxFeeBumpInnerSuccess(pair)
+        | TransactionResultResult::TxFeeBumpInnerFailed(pair) => {
+            inner_transaction_result_set(&pair.result.result)
+        }
+        result => TransactionResultSet {
+            operation_results: &[],
+            transaction_failure: Some(result.name()),
+            committed: false,
+        },
+    }
+}
+
+fn inner_transaction_result_set(result: &InnerTransactionResultResult) -> TransactionResultSet<'_> {
+    match result {
+        InnerTransactionResultResult::TxSuccess(results) => TransactionResultSet {
+            operation_results: results.as_ref(),
+            transaction_failure: None,
+            committed: true,
+        },
+        InnerTransactionResultResult::TxFailed(results) => TransactionResultSet {
+            operation_results: results.as_ref(),
+            transaction_failure: Some("TxFailed"),
+            committed: false,
+        },
+        result => TransactionResultSet {
+            operation_results: &[],
+            transaction_failure: Some(result.name()),
+            committed: false,
+        },
+    }
+}
+
+fn resource_summary(
+    resources: &crate::decode::resource_analyzer::TransactionResultMeta,
+) -> crate::types::report::ResourceSummary {
+    crate::types::report::ResourceSummary {
+        cpu_instructions_used: resources.resources_consumed.cpu_instructions,
+        cpu_instructions_limit: resources.resources_allocated.cpu_instructions,
+        memory_bytes_used: resources.resources_consumed.memory_bytes,
+        memory_bytes_limit: resources.resources_allocated.memory_bytes,
+        read_bytes: resources.resources_consumed.read_bytes,
+        read_bytes_limit: resources.resources_allocated.read_bytes,
+        write_bytes: resources.resources_consumed.write_bytes,
+    }
+}
+
+fn decode_operation_result(
+    operation: &Operation,
+    result: Option<&OperationResult>,
+    transaction_failure: Option<&str>,
+) -> DecodedOperationResult {
+    let default_category = if is_soroban_operation(operation) {
+        "Soroban"
+    } else {
+        "ClassicStellar"
+    };
+    let Some(result) = result else {
+        return DecodedOperationResult {
+            success: false,
+            attempted: false,
+            category: default_category.to_string(),
+            code: transaction_failure
+                .unwrap_or("MissingOperationResult")
+                .to_string(),
+        };
+    };
+    match result {
+        OperationResult::OpInner(inner) if inner.name() != operation.body.name() => {
+            DecodedOperationResult {
+                success: false,
+                attempted: true,
+                category: "Xdr".into(),
+                code: "OperationResultTypeMismatch".into(),
+            }
+        }
+        OperationResult::OpInner(inner) => {
+            let code = inner_result_code(inner).unwrap_or_else(|| "UnknownResult".into());
+            DecodedOperationResult {
+                success: code == "Success",
+                attempted: true,
+                category: result_category(operation, &code).into(),
+                code,
+            }
+        }
+        error => DecodedOperationResult {
+            success: false,
+            attempted: true,
+            category: default_category.into(),
+            code: error.name().into(),
+        },
+    }
+}
+
+fn result_category(operation: &Operation, code: &str) -> &'static str {
+    if !is_soroban_operation(operation) {
+        return "ClassicStellar";
+    }
+    match code {
+        "ResourceLimitExceeded" => "Budget",
+        "EntryArchived" => "Storage",
+        "Malformed" | "InsufficientRefundableFee" => "Context",
+        _ => "Soroban",
+    }
+}
+
+fn inner_result_code(result: &OperationResultTr) -> Option<String> {
+    let serialized = serde_json::to_value(result).ok()?;
+    let payload = match serialized {
+        Value::Object(map) => map.into_iter().next()?.1,
+        _ => return None,
+    };
+    let name = match payload {
+        Value::String(name) => name,
+        Value::Object(map) => map.into_iter().next()?.0,
+        _ => return None,
+    };
+    Some(to_pascal_case(&name))
+}
+
+fn to_pascal_case(value: &str) -> String {
+    let mut output = String::new();
+    for part in value.split('_') {
+        let mut chars = part.chars();
+        if let Some(first) = chars.next() {
+            output.extend(first.to_uppercase());
+            output.extend(chars);
+        }
+    }
+    output
+}
+
+fn extract_xdr_arguments<T: Serialize>(value: &T) -> Vec<String> {
+    let Ok(serialized) = serde_json::to_value(value) else {
+        return Vec::new();
+    };
+    let payload = match serialized {
+        Value::String(_) => return Vec::new(),
+        Value::Object(map) if map.len() == 1 => map.into_iter().next().map(|entry| entry.1),
+        value => Some(value),
+    };
+    match payload {
+        Some(Value::Object(fields)) => fields
+            .into_iter()
+            .map(|(name, value)| format!("{name}: {}", compact_json(&value)))
+            .collect(),
+        Some(Value::Null) | None => Vec::new(),
+        Some(value) => vec![compact_json(&value)],
+    }
+}
+
+fn compact_json(value: &Value) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| value.to_string())
+}
+
+fn format_scval(value: &ScVal) -> String {
+    compact_json(&crate::decode::scval_to_json(value))
+}
+
+fn is_soroban_operation(operation: &Operation) -> bool {
+    matches!(
+        operation.body,
+        OperationBody::InvokeHostFunction(_)
+            | OperationBody::ExtendFootprintTtl(_)
+            | OperationBody::RestoreFootprint(_)
+    )
+}
+
+fn is_invoke_contract(operation: &Operation) -> bool {
+    matches!(operation.body, OperationBody::InvokeHostFunction(ref invoke)
+        if matches!(invoke.host_function, HostFunction::InvokeContract(_)))
+}
+
+fn single_invoke_contract_index(operations: &[Operation]) -> Option<usize> {
+    let mut indexes = operations
+        .iter()
+        .enumerate()
+        .filter_map(|(index, operation)| is_invoke_contract(operation).then_some(index));
+    let only = indexes.next()?;
+    indexes.next().is_none().then_some(only)
+}
+
+fn decode_soroban_meta(tx_data: &Value) -> GratResult<Option<SorobanTransactionMeta>> {
+    let Some(xdr) = tx_data.get("resultMetaXdr").and_then(Value::as_str) else {
+        return Ok(None);
+    };
+    let meta = TransactionMeta::from_xdr_base64(xdr)
+        .map_err(|error| GratError::Internal(format!("Failed to decode resultMetaXdr: {error}")))?;
+    Ok(match meta {
+        TransactionMeta::V3(meta) => meta.soroban_meta,
+        TransactionMeta::V0(_) | TransactionMeta::V1(_) | TransactionMeta::V2(_) => None,
+    })
+}
+
+fn partition_diagnostic_events(
+    events: &[DiagnosticEvent],
+    operations: &[Operation],
 ) -> Vec<Vec<DiagnosticEvent>> {
-    if num_operations <= 1 || diagnostic_events.is_empty() {
-        return vec![diagnostic_events.to_vec()];
+    let mut partitions = vec![Vec::new(); operations.len()];
+    if events.is_empty() {
+        return partitions;
+    }
+    let invokes: Vec<usize> = operations
+        .iter()
+        .enumerate()
+        .filter_map(|(i, operation)| is_invoke_contract(operation).then_some(i))
+        .collect();
+    let soroban: Vec<usize> = operations
+        .iter()
+        .enumerate()
+        .filter_map(|(i, operation)| is_soroban_operation(operation).then_some(i))
+        .collect();
+    if soroban.len() == 1 {
+        partitions[soroban[0]] = events.to_vec();
+        return partitions;
     }
 
-    let mut partitions: Vec<Vec<DiagnosticEvent>> = vec![Vec::new(); num_operations];
-    let mut depth: usize = 0;
-    let mut current_op: usize = 0;
-
-    for event in diagnostic_events {
-        #[allow(irrefutable_let_patterns)]
-        if let ContractEventBody::V0(v0) = &event.event.body {
-            let is_call = v0.topics.iter().any(|t| {
-                if let ScVal::Symbol(s) = t {
-                    let s_low = s.to_string().to_lowercase();
-                    s_low == "fn_call" || s_low == "function_call" || s_low == "call"
-                } else {
-                    false
+    let mut depth = 0usize;
+    let mut cursor = 0usize;
+    let mut active = None;
+    for event in events {
+        if diagnostic_event_has_topic(event, is_call_topic) {
+            if depth == 0 {
+                active = invokes.get(cursor).copied();
+                if active.is_some() {
+                    cursor += 1;
                 }
-            });
-
-            if is_call {
-                if depth == 0 && current_op < num_operations {
-                    current_op += 1;
-                }
-                depth += 1;
             }
-
-            if current_op > 0 && current_op <= num_operations {
-                partitions[current_op - 1].push(event.clone());
-            }
-
-            let is_return = v0.topics.iter().any(|t| {
-                if let ScVal::Symbol(s) = t {
-                    let s_low = s.to_string().to_lowercase();
-                    s_low == "fn_return" || s_low == "function_return" || s_low == "return"
-                } else {
-                    false
-                }
-            });
-
-            if is_return {
-                depth = depth.saturating_sub(1);
+            depth += 1;
+        }
+        if let Some(index) = active {
+            partitions[index].push(event.clone());
+        }
+        if diagnostic_event_has_topic(event, is_return_topic) {
+            depth = depth.saturating_sub(1);
+            if depth == 0 {
+                active = None;
             }
         }
     }
-
     partitions
 }
 
-fn partition_contract_events_by_operation(
-    contract_events: &[ContractEvent],
-    num_operations: usize,
+fn diagnostic_event_has_topic(event: &DiagnosticEvent, predicate: fn(&str) -> bool) -> bool {
+    #[allow(irrefutable_let_patterns)]
+    if let ContractEventBody::V0(body) = &event.event.body {
+        return body.topics.iter().any(|topic| match topic {
+            ScVal::Symbol(value) => predicate(&value.to_string()),
+            ScVal::String(value) => predicate(&value.to_string()),
+            _ => false,
+        });
+    }
+    false
+}
+
+fn is_call_topic(value: &str) -> bool {
+    matches!(
+        value.to_ascii_lowercase().as_str(),
+        "fn_call" | "function_call" | "call"
+    )
+}
+
+fn is_return_topic(value: &str) -> bool {
+    matches!(
+        value.to_ascii_lowercase().as_str(),
+        "fn_return" | "function_return" | "return"
+    )
+}
+
+fn return_value_from_events(events: &[DiagnosticEvent]) -> Option<&ScVal> {
+    events.iter().rev().find_map(|event| {
+        if !diagnostic_event_has_topic(event, is_return_topic) {
+            return None;
+        }
+        #[allow(irrefutable_let_patterns)]
+        let ContractEventBody::V0(body) = &event.event.body;
+        Some(&body.data)
+    })
+}
+
+fn partition_contract_events(
+    events: &[ContractEvent],
+    operations: &[Operation],
 ) -> Vec<Vec<ContractEvent>> {
-    if num_operations <= 1 || contract_events.is_empty() {
-        return vec![contract_events.to_vec()];
+    let mut partitions = vec![Vec::new(); operations.len()];
+    if events.is_empty() {
+        return partitions;
     }
-
-    let mut partitions: Vec<Vec<ContractEvent>> = vec![Vec::new(); num_operations];
-    let mut depth: usize = 0;
-    let mut current_op: usize = 0;
-
-    for event in contract_events {
-        #[allow(irrefutable_let_patterns)]
-        if let ContractEventBody::V0(v0) = &event.body {
-            let is_call = v0.topics.iter().any(|t| {
-                if let ScVal::Symbol(s) = t {
-                    let s_low = s.to_string().to_lowercase();
-                    s_low == "fn_call" || s_low == "function_call" || s_low == "call"
-                } else {
-                    false
-                }
-            });
-
-            if is_call {
-                if depth == 0 && current_op < num_operations {
-                    current_op += 1;
-                }
-                depth += 1;
-            }
-
-            if current_op > 0 && current_op <= num_operations {
-                partitions[current_op - 1].push(event.clone());
-            }
-
-            let is_return = v0.topics.iter().any(|t| {
-                if let ScVal::Symbol(s) = t {
-                    let s_low = s.to_string().to_lowercase();
-                    s_low == "fn_return" || s_low == "function_return" || s_low == "return"
-                } else {
-                    false
-                }
-            });
-
-            if is_return {
-                depth = depth.saturating_sub(1);
+    let soroban: Vec<usize> = operations
+        .iter()
+        .enumerate()
+        .filter_map(|(i, operation)| is_soroban_operation(operation).then_some(i))
+        .collect();
+    if soroban.len() == 1 {
+        partitions[soroban[0]] = events.to_vec();
+        return partitions;
+    }
+    for event in events {
+        let Some(contract_id) = event.contract_id.as_ref() else {
+            continue;
+        };
+        for (index, operation) in operations.iter().enumerate() {
+            if invoked_contract_id(operation).is_some_and(|target| target == contract_id) {
+                partitions[index].push(event.clone());
+                break;
             }
         }
     }
-
     partitions
 }
 
-fn enrich_diagnostic_report(
-    report: &mut DiagnosticReport,
-    tx_data: &serde_json::Value,
-) -> crate::error::GratResult<()> {
-    crate::decode::diagnostic::enrich_report(report, tx_data)
+fn invoked_contract_id(operation: &Operation) -> Option<&stellar_xdr::curr::Hash> {
+    let OperationBody::InvokeHostFunction(invoke) = &operation.body else {
+        return None;
+    };
+    let HostFunction::InvokeContract(args) = &invoke.host_function else {
+        return None;
+    };
+    match &args.contract_address {
+        ScAddress::Contract(contract_id) => Some(contract_id),
+        ScAddress::Account(_) => None,
+    }
 }
 
-fn enrich_resource_report(
+#[allow(clippy::too_many_arguments)]
+fn build_operation_report(
+    tx_data: &Value,
+    count: usize,
+    index: usize,
+    operation: &Operation,
+    decoded: DecodedOperation,
+    result: DecodedOperationResult,
+    transaction_committed: bool,
+    diagnostics: &[DiagnosticEvent],
+    events: &[ContractEvent],
+    resources: &crate::decode::resource_analyzer::TransactionResultMeta,
+    fee: crate::types::report::FeeBreakdown,
+    resource_summary: crate::types::report::ResourceSummary,
+) -> DiagnosticReport {
+    let committed = transaction_committed && result.success;
+    let outcome = if committed {
+        "succeeded"
+    } else if result.success {
+        "was rolled back"
+    } else if result.attempted {
+        "failed"
+    } else {
+        "was not executed"
+    };
+    let mut report = DiagnosticReport::new(
+        &result.category,
+        0,
+        &result.code,
+        &format!(
+            "Operation {}/{} ({}) {}",
+            index + 1,
+            count,
+            decoded.operation_name,
+            outcome
+        ),
+    );
+    report.severity = if committed {
+        Severity::Info
+    } else if result.success {
+        Severity::Warning
+    } else {
+        Severity::Error
+    };
+    report.operation_index = Some(index);
+    report.operation_count = Some(count);
+    report.detailed_explanation = operation_explanation(
+        index,
+        count,
+        &decoded.operation_name,
+        &result,
+        transaction_committed,
+    );
+    report.transaction_context = Some(crate::types::report::TransactionContext {
+        tx_hash: tx_data
+            .get("hash")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string(),
+        ledger_sequence: tx_data.get("ledger").and_then(Value::as_u64).unwrap_or(0) as u32,
+        function_name: Some(decoded.display_name),
+        arguments: decoded.arguments,
+        return_value: decoded.return_value,
+        fee,
+        resources: resource_summary,
+        operation_index: Some(index),
+        operation_count: Some(count),
+    });
+    enrich_operation_report(
+        &mut report,
+        tx_data,
+        operation,
+        &result,
+        diagnostics,
+        events,
+        resources,
+        index,
+    );
+    report
+}
+
+#[allow(clippy::too_many_arguments)]
+fn enrich_operation_report(
     report: &mut DiagnosticReport,
-    tx_data: &serde_json::Value,
-) -> crate::error::GratResult<()> {
-    crate::decode::resource_analyzer::enrich_report(report, tx_data);
-    Ok(())
+    tx_data: &Value,
+    operation: &Operation,
+    result: &DecodedOperationResult,
+    diagnostics: &[DiagnosticEvent],
+    events: &[ContractEvent],
+    _resources: &crate::decode::resource_analyzer::TransactionResultMeta,
+    index: usize,
+) {
+    if !diagnostics.is_empty() {
+        let encoded: Vec<String> = diagnostics
+            .iter()
+            .filter_map(|event| event.to_xdr_base64().ok())
+            .collect();
+        let data = serde_json::json!({
+            "diagnosticEventsXdr": encoded,
+            "hash": tx_data.get("hash"),
+            "ledger": tx_data.get("ledger"),
+        });
+        let _ = crate::decode::diagnostic::enrich_report(report, &data);
+    }
+    if is_soroban_operation(operation) && !result.success {
+        crate::decode::resource_analyzer::enrich_report(report, tx_data);
+    }
+    let function_name = report
+        .transaction_context
+        .as_ref()
+        .and_then(|context| context.function_name.clone());
+    report.cross_contract_attribution = failure_attribution(events, function_name, index);
+}
+
+fn failure_attribution(
+    events: &[ContractEvent],
+    function_name: Option<String>,
+    index: usize,
+) -> Option<crate::types::report::FailureAttribution> {
+    let contract_id = events.iter().find_map(|event| event.contract_id.as_ref())?;
+    Some(crate::types::report::FailureAttribution {
+        contract_address: contract_id
+            .0
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect(),
+        function_name,
+        call_depth: 0,
+        origin_description: format!("Operation {}", index + 1),
+    })
+}
+
+fn operation_explanation(
+    index: usize,
+    count: usize,
+    name: &str,
+    result: &DecodedOperationResult,
+    transaction_committed: bool,
+) -> String {
+    let mut explanation = format!(
+        "Operation {}/{} is a {} operation. Its XDR result is {}.",
+        index + 1,
+        count,
+        name,
+        result.code,
+    );
+    if result.success && !transaction_committed {
+        explanation.push_str(
+            " The operation-level result was successful, but its effects were rolled back because the atomic transaction failed.",
+        );
+    } else if !result.attempted {
+        explanation.push_str(" The transaction failed before this operation was executed.");
+    }
+    explanation
 }
 
 pub async fn decode_transaction_with_op_filter(
@@ -509,16 +732,30 @@ pub async fn decode_transaction_with_op_filter(
 ) -> GratResult<Vec<DiagnosticReport>> {
     let rpc = SorobanRpcClient::new(network);
     let tx_data = rpc.get_transaction(tx_hash).await?;
-    let tx_json = serde_json::to_value(&tx_data)
-        .map_err(|e| crate::error::GratError::Internal(e.to_string()))?;
-    let decoder = MultiOpDecoder::new();
-    let reports = decoder.decode_transaction(&tx_json)?;
-
-    if let Some(idx) = op_index {
-        if idx < reports.len() {
-            return Ok(vec![reports[idx].clone()]);
-        }
+    let tx_json =
+        serde_json::to_value(&tx_data).map_err(|error| GratError::Internal(error.to_string()))?;
+    let reports = MultiOpDecoder::new().decode_transaction(&tx_json)?;
+    match op_index {
+        Some(index) => reports
+            .get(index)
+            .cloned()
+            .map(|report| vec![report])
+            .ok_or_else(|| {
+                GratError::Internal(format!(
+                    "Operation index {index} is out of range for a transaction with {} operations",
+                    reports.len(),
+                ))
+            }),
+        None => Ok(reports),
     }
+}
 
-    Ok(reports)
+impl MultiOpDecoder {
+    fn decode_operation(
+        &self,
+        operation: &Operation,
+        return_value: Option<&ScVal>,
+    ) -> DecodedOperation {
+        decode_operation_payload(&self.function_call_decoder, operation, return_value)
+    }
 }


### PR DESCRIPTION
## Description

This PR adds full multi-operation transaction decoding support.

Grat now processes every operation in a transaction envelope instead of assuming the transaction contains a single `InvokeHostFunction` operation. Transactions containing classic Stellar operations and multiple Soroban operations now produce a separate diagnostic report for each operation.

## How It Was Done

- Added envelope-wide operation iteration for V0, V1, and fee-bump transactions.
- Preserved the original operation index and order in all generated reports.
- Added operation-specific decoding:
  - Soroban contract calls use `FunctionCallDecoder`.
  - Classic Stellar and other Soroban operations use structured XDR extraction.
- Matched each operation with its corresponding XDR result.
- Added support for transaction-level failures and operations that were not executed.
- Distinguished operation failures from successful operations rolled back by atomic transaction failure.
- Associated diagnostic and contract events with their relevant Soroban operation where possible.
- Added clear `Operation N/Total` labels and operation metadata to diagnostic reports.
- Added validation for out-of-range operation filters.
- Added regression tests for classic operation success, missing results, and result-type mismatches.

## Issues Encountered (If Any)

The local Rust compilation environment did not include `gcc.exe`, which is required to build the `ring` dependency under the configured GNU toolchain.

The implementation was kept strictly within the requested decoder files.

## Related Issue

Closes #392 

## How It Was Tested

- Added focused unit tests for:
  - Successful classic Stellar operations.
  - Missing operation results.
  - Mismatched operation and result types.
- Ran `cargo fmt --all -- --check` successfully.
- Ran `git diff --check` successfully.
- Confirmed that only the requested decoder files were modified.
- Full Cargo tests should be rerun in an environment with MinGW/GCC installed:

  `cargo test -p grat-core --lib`

## Screenshots / Video (If Applicable)

Not applicable. This PR only changes core transaction decoding behavior.