### PR TITLE
feat(ui): add DiagnosticBadge component for terminal output

### DIFF
--- a/crates/cli/src/ui/badges.rs
+++ b/crates/cli/src/ui/badges.rs
@@ -1,0 +1,79 @@
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticCategory {
+    Success,
+    Info,
+    Warning,
+    Error,
+}
+
+impl DiagnosticCategory {
+    pub fn icon(&self) -> &'static str {
+        match self {
+            DiagnosticCategory::Success => "✔",
+            DiagnosticCategory::Info => "ℹ",
+            DiagnosticCategory::Warning => "⚠",
+            DiagnosticCategory::Error => "✖",
+        }
+    }
+
+    pub fn fallback(&self) -> &'static str {
+        match self {
+            DiagnosticCategory::Success => "[SUCCESS]",
+            DiagnosticCategory::Info => "[INFO]",
+            DiagnosticCategory::Warning => "[WARN]",
+            DiagnosticCategory::Error => "[ERROR]",
+        }
+    }
+
+    pub fn color_code(&self) -> &'static str {
+        match self {
+            DiagnosticCategory::Success => "\x1b[32m",
+            DiagnosticCategory::Info => "\x1b[34m",
+            DiagnosticCategory::Warning => "\x1b[33m",
+            DiagnosticCategory::Error => "\x1b[31m",
+        }
+    }
+}
+
+pub struct DiagnosticBadge {
+    pub category: DiagnosticCategory,
+    pub supports_unicode: bool,
+}
+
+impl DiagnosticBadge {
+    pub fn new(category: DiagnosticCategory, supports_unicode: bool) -> Self {
+        Self {
+            category,
+            supports_unicode,
+        }
+    }
+
+    pub fn format_message(&self, message: &str) -> String {
+        let badge_text = if self.supports_unicode {
+            self.category.icon()
+        } else {
+            self.category.fallback()
+        };
+
+        format!(
+            "{}{} \x1b[0m{}",
+            self.category.color_code(),
+            badge_text,
+            message
+        )
+    }
+}
+
+impl fmt::Display for DiagnosticBadge {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let badge_text = if self.supports_unicode {
+            self.category.icon()
+        } else {
+            self.category.fallback()
+        };
+
+        write!(f, "{}{}\x1b[0m", self.category.color_code(), badge_text)
+    }
+}


### PR DESCRIPTION
## 📝 Description
This PR introduces the DiagnosticBadge component to improve the visual scannability of terminal output. It maps diagnostic metadata (categories/severities) to specific Unicode symbols and provides immediate visual cues using ANSI coloring. Safe ASCII fallbacks are also implemented to ensure compatibility with legacy terminal environments that do not support complex emojis or ligatures.

## 🔗 Related Issues
Resolves: #409 

## 🛠️ Changes Made
- Added DiagnosticCategory enum: Maps Success, Info, Warning, and Error severities to distinct Unicode icons (✔, ℹ, ⚠, ✖) and ASCII fallbacks.
- Added DiagnosticBadge struct: Acts as the formatting UI component to gracefully prepend colored badges to terminal messages.
- Fallback handling: Built-in environment toggle (supports_unicode) guarantees terminal safety.

## 📂 File Changes
Note: The issue requested `apps/cli/src/ui/badges.rs`, but standardizing with your workspace, this is intended for the CLI UI module in `crates/cli/src/ui/badges.rs`.

## ✅ Checklist
- [x] I have read the `CONTRIBUTING.md` file.
- [x] My code follows the code style of this project.
- [x] I have implemented fallback mechanisms for non-Unicode environments.
- [x] ANSI color codes are correctly terminated so formatting does not bleed into user logs.