### PR TITLE
test: add unit test for argument table with empty inputs (Closes #424)

### DIFF
--- a/crates/cli/src/output/renderers.rs
+++ b/crates/cli/src/output/renderers.rs
@@ -609,6 +609,40 @@ mod tests {
     }
 
     #[test]
+    fn render_context_table_with_empty_arguments() {
+        let context = TransactionContext {
+            tx_hash: "abc123".to_string(),
+            ledger_sequence: 12345,
+            operation_count: Some(0),
+            operation_index: Some(0),
+            function_name: Some("transfer".to_string()),
+            arguments: vec![],
+            fee: FeeBreakdown {
+                total_charged_fee: 150,
+                inclusion_fee: 100,
+                resource_fee: 50,
+                refundable_resource_fee: 25,
+                refundable_fee: 25,
+                non_refundable_fee: 25,
+                bid_fee: Some(150),
+            },
+            resources: ResourceSummary {
+                cpu_instructions_used: 1000,
+                cpu_instructions_limit: 10000,
+                memory_bytes_used: 5000,
+                memory_bytes_limit: 50000,
+                read_bytes: 1000,
+                read_bytes_limit: 10000,
+                write_bytes: 500,
+            },
+            return_value: None,
+        };
+
+        let output = render_context_table(&context);
+        assert!(output.is_empty());
+    }
+
+    #[test]
     fn render_fee_breakdown_works() {
         let fee = FeeBreakdown {
             total_charged_fee: 150,


### PR DESCRIPTION
## Summary

Adds a unit test for `render_context_table` covering the empty-arguments edge case.

When `TransactionContext.arguments` is empty, the function returns an empty string via an early-return branch. This branch was previously untested, so this PR closes that gap.

## What Changed

| File | Change |
|------|--------|
| `crates/cli/src/output/renderers.rs` | Added `render_context_table_with_empty_arguments` test |

## Test Details

The new test constructs a `TransactionContext` with `arguments: vec![]` and asserts that `render_context_table` returns an empty string (`output.is_empty()`). This mirrors the structure of the existing `render_context_table_with_arguments` test for consistency.

```rust
#[test]
fn render_context_table_with_empty_arguments() {
    let context = TransactionContext {
        tx_hash: "abc123".to_string(),
        ledger_sequence: 12345,
        operation_count: Some(0),
        operation_index: Some(0),
        function_name: Some("transfer".to_string()),
        arguments: vec![],          // ← empty inputs
        fee: FeeBreakdown { /* ... */ },
        resources: ResourceSummary { /* ... */ },
        return_value: None,
    };

    let output = render_context_table(&context);
    assert!(output.is_empty());
}
```

## CI Verification

All CI checks pass locally before opening this PR:

| Check | Result |
|-------|--------|
| `cargo fmt --all -- --check` | ✅ Pass |
| `cargo build --workspace --all-targets --all-features` | ✅ Pass |
| `cargo test --workspace --all-targets --all-features` | ✅ 417 tests pass (including the new one) |
| `scripts/lint_taxonomy.sh` | ✅ Pass |
| `pnpm lint` | ✅ 0 errors (pre-existing warnings only) |
| `pnpm typecheck` | ✅ Pass |

## Motivation

The `render_context_table` function has an early-return path for empty arguments that was not covered by any test. Adding this test ensures the edge case is explicitly validated, preventing future regressions if the empty-arguments handling is changed.

Closes #424