### PR TITLE
Feat/search error

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -9,7 +9,7 @@ pub mod export;
 pub mod inspect;
 pub mod profile;
 pub mod replay;
+pub mod search_error;
 pub mod serve;
 pub mod trace;
 pub mod whatif;
-pub mod search_error;

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -12,3 +12,4 @@ pub mod replay;
 pub mod serve;
 pub mod trace;
 pub mod whatif;
+pub mod search_error;

--- a/crates/cli/src/commands/search_error.rs
+++ b/crates/cli/src/commands/search_error.rs
@@ -4,7 +4,9 @@ use tabled::Table;
 use tabled::Tabled;
 
 #[derive(Parser, Debug)]
-#[command(about = "Search the taxonomy database for specific error names, categories, or descriptions")]
+#[command(
+    about = "Search the taxonomy database for specific error names, categories, or descriptions"
+)]
 pub struct SearchErrorArgs {
     #[arg(help = "The search query (case-insensitive substring match)")]
     pub query: String,

--- a/crates/cli/src/commands/search_error.rs
+++ b/crates/cli/src/commands/search_error.rs
@@ -1,0 +1,49 @@
+use clap::Parser;
+use grat_core::taxonomy::loader::TaxonomyDatabase;
+use tabled::Table;
+use tabled::Tabled;
+
+#[derive(Parser, Debug)]
+#[command(about = "Search the taxonomy database for specific error names, categories, or descriptions")]
+pub struct SearchErrorArgs {
+    #[arg(help = "The search query (case-insensitive substring match)")]
+    pub query: String,
+}
+
+#[derive(Tabled)]
+struct SearchResultRow {
+    #[tabled(rename = "Category")]
+    category: String,
+    #[tabled(rename = "Code")]
+    code: u32,
+    #[tabled(rename = "Name")]
+    name: String,
+    #[tabled(rename = "Summary")]
+    summary: String,
+}
+
+pub async fn run(args: SearchErrorArgs) -> anyhow::Result<()> {
+    let db = TaxonomyDatabase::load_latest()?;
+
+    let results = db.search(&args.query);
+
+    if results.is_empty() {
+        println!("No matching entries found for '{}'", args.query);
+        return Ok(());
+    }
+
+    let rows: Vec<SearchResultRow> = results
+        .into_iter()
+        .map(|entry| SearchResultRow {
+            category: entry.category.to_string(),
+            code: entry.code,
+            name: entry.name.clone(),
+            summary: entry.summary.clone(),
+        })
+        .collect();
+
+    let table = Table::new(rows);
+    println!("{table}");
+
+    Ok(())
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -86,7 +86,6 @@ enum Commands {
 
     Serve(commands::serve::ServeArgs),
 
-    #[command(alias = "search-error")]
     SearchError(commands::search_error::SearchErrorArgs),
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -85,6 +85,9 @@ enum Commands {
     },
 
     Serve(commands::serve::ServeArgs),
+
+    #[command(alias = "search-error")]
+    SearchError(commands::search_error::SearchErrorArgs),
 }
 
 #[tokio::main]
@@ -157,6 +160,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::Auth(args) => commands::auth::run(args, &cli.output).await?,
         Commands::Diagnostic(args) => commands::diagnostic::run(args).await?,
         Commands::Serve(args) => commands::serve::run(args, &network).await?,
+        Commands::SearchError(args) => commands::search_error::run(args).await?,
         Commands::Completions { shell } => {
             let mut cmd = Cli::command();
             let name = cmd.get_name().to_string();

--- a/crates/core/src/cache/wasm.rs
+++ b/crates/core/src/cache/wasm.rs
@@ -1,7 +1,6 @@
 use crate::cache::provider::CacheProvider;
 use crate::error::GratResult;
 use sha2::{Digest, Sha256};
-use std::future::Future;
 
 /// Specialized cache for compiled WebAssembly modules.
 /// Uses a cryptographic hash (SHA-256) of the original Wasm bytecode as the key
@@ -47,7 +46,7 @@ impl<P: CacheProvider> WasmCache<P> {
 mod tests {
     use super::*;
     use crate::cache::provider::CacheProvider;
-    use crate::error::{GratError, GratResult};
+    use crate::error::GratResult;
     use serde::{de::DeserializeOwned, Serialize};
     use std::collections::HashMap;
     use std::sync::Mutex;

--- a/crates/core/src/taxonomy/loader.rs
+++ b/crates/core/src/taxonomy/loader.rs
@@ -130,6 +130,19 @@ impl TaxonomyDatabase {
             .collect()
     }
 
+    pub fn search(&self, query: &str) -> Vec<&TaxonomyEntry> {
+        let query = query.to_lowercase();
+        self.all_entries
+            .iter()
+            .filter(|entry| {
+                entry.name.to_lowercase().contains(&query)
+                    || entry.category.to_string().to_lowercase().contains(&query)
+                    || entry.summary.to_lowercase().contains(&query)
+                    || entry.detailed_explanation.to_lowercase().contains(&query)
+            })
+            .collect()
+    }
+
     pub fn all_entries(&self) -> &[TaxonomyEntry] {
         &self.all_entries
     }


### PR DESCRIPTION
## Description

Added a new `search-error` CLI subcommand that allows users to quickly search the taxonomy database for Soroban and Stellar transaction errors without manually opening taxonomy files.

The search supports case-insensitive substring matching across error names, categories, summaries, and detailed explanations.

## How It Was Done

* Added the `SearchError` command to the `Commands` enum.
* Added the `search_error.rs` command implementation.
* Exposed a search interface on `TaxonomyDatabase`.
* Implemented case-insensitive substring matching across taxonomy fields.
* Used the `tabled` crate to format matching results into a clean, readable table.
* Registered the new command module in `commands/mod.rs`.

## Issues Encountered (If Any)

No significant issues were encountered during implementation.

The search behavior was kept as substring matching so users can find errors using partial names or descriptions.

## Related Issue

Closes #419 

## How It Was Tested

* Ran the CLI test suite.
* Verified the new command builds successfully.
* Tested searches using exact and partial error names.
* Verified matching is case insensitive.
* Verified results include the error name, category, and summary.
* Verified searches against descriptions and explanations return relevant entries.
* Verified the command handles searches with no matching results correctly.

## Screenshots / Video (If Applicable)

Not applicable. This is a CLI feature with no graphical UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to search the taxonomy database for error information.
  * Search is case-insensitive and matches names, categories, summaries, and detailed explanations.
  * Results are displayed in a formatted table with category, code, name, and summary.
  * Clear feedback is provided when no matching entries are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->