### PR TITLE
test(cli): add unit tests for ColorPalette non-TTY color suppression

### DIFF
--- a/crates/cli/src/output/theme.rs
+++ b/crates/cli/src/output/theme.rs
@@ -68,3 +68,213 @@ impl ColorPalette {
         Self::paint(text, self.accent)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// A guard that serializes tests touching the global COLOR_ENABLED flag and
+    /// restores its original value when dropped, so parallel test runners cannot
+    /// interfere with each other.
+    static LOCK: Mutex<()> = Mutex::new(());
+
+    struct ColorGuard {
+        original: bool,
+        _guard: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl ColorGuard {
+        fn acquire(enabled: bool) -> Self {
+            // Poison recovery: if a previous test panicked while holding the
+            // lock the mutex becomes poisoned; we recover and continue.
+            let guard = match LOCK.lock() {
+                Ok(g) => g,
+                Err(e) => e.into_inner(),
+            };
+            let original = colors_enabled();
+            set_color_enabled(enabled);
+            ColorGuard { original, _guard: guard }
+        }
+    }
+
+    impl Drop for ColorGuard {
+        fn drop(&mut self) {
+            set_color_enabled(self.original);
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // Helper                                                               //
+    // ------------------------------------------------------------------ //
+
+    fn has_ansi(s: &str) -> bool {
+        s.contains('\x1b')
+    }
+
+    // ------------------------------------------------------------------ //
+    // Non-TTY (colors disabled) tests                                     //
+    // ------------------------------------------------------------------ //
+
+    #[test]
+    fn error_text_no_ansi_when_colors_disabled() {
+        let _g = ColorGuard::acquire(false);
+        let palette = ColorPalette::default();
+        let result = palette.error_text("something failed");
+        assert_eq!(result, "something failed");
+        assert!(!has_ansi(&result), "expected no ANSI codes, got: {:?}", result);
+    }
+
+    #[test]
+    fn warning_text_no_ansi_when_colors_disabled() {
+        let _g = ColorGuard::acquire(false);
+        let palette = ColorPalette::default();
+        let result = palette.warning_text("low disk space");
+        assert_eq!(result, "low disk space");
+        assert!(!has_ansi(&result), "expected no ANSI codes, got: {:?}", result);
+    }
+
+    #[test]
+    fn success_text_no_ansi_when_colors_disabled() {
+        let _g = ColorGuard::acquire(false);
+        let palette = ColorPalette::default();
+        let result = palette.success_text("transaction confirmed");
+        assert_eq!(result, "transaction confirmed");
+        assert!(!has_ansi(&result), "expected no ANSI codes, got: {:?}", result);
+    }
+
+    #[test]
+    fn metadata_text_no_ansi_when_colors_disabled() {
+        let _g = ColorGuard::acquire(false);
+        let palette = ColorPalette::default();
+        let result = palette.metadata_text("ledger: 12345");
+        assert_eq!(result, "ledger: 12345");
+        assert!(!has_ansi(&result), "expected no ANSI codes, got: {:?}", result);
+    }
+
+    #[test]
+    fn muted_text_no_ansi_when_colors_disabled() {
+        let _g = ColorGuard::acquire(false);
+        let palette = ColorPalette::default();
+        let result = palette.muted_text("optional detail");
+        assert_eq!(result, "optional detail");
+        assert!(!has_ansi(&result), "expected no ANSI codes, got: {:?}", result);
+    }
+
+    #[test]
+    fn accent_text_no_ansi_when_colors_disabled() {
+        let _g = ColorGuard::acquire(false);
+        let palette = ColorPalette::default();
+        let result = palette.accent_text("highlighted");
+        assert_eq!(result, "highlighted");
+        assert!(!has_ansi(&result), "expected no ANSI codes, got: {:?}", result);
+    }
+
+    #[test]
+    fn all_methods_return_raw_string_when_colors_disabled() {
+        let _g = ColorGuard::acquire(false);
+        let palette = ColorPalette::default();
+        let input = "test string";
+
+        for result in [
+            palette.error_text(input),
+            palette.warning_text(input),
+            palette.success_text(input),
+            palette.metadata_text(input),
+            palette.muted_text(input),
+            palette.accent_text(input),
+        ] {
+            assert_eq!(result, input, "expected raw string, got: {:?}", result);
+            assert!(!has_ansi(&result), "unexpected ANSI in: {:?}", result);
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // TTY (colors enabled) tests                                          //
+    // ------------------------------------------------------------------ //
+
+    #[test]
+    fn error_text_contains_ansi_when_colors_enabled() {
+        let _g = ColorGuard::acquire(true);
+        let palette = ColorPalette::default();
+        let result = palette.error_text("something failed");
+        assert!(has_ansi(&result), "expected ANSI codes, got: {:?}", result);
+    }
+
+    #[test]
+    fn warning_text_contains_ansi_when_colors_enabled() {
+        let _g = ColorGuard::acquire(true);
+        let palette = ColorPalette::default();
+        let result = palette.warning_text("low disk space");
+        assert!(has_ansi(&result), "expected ANSI codes, got: {:?}", result);
+    }
+
+    #[test]
+    fn success_text_contains_ansi_when_colors_enabled() {
+        let _g = ColorGuard::acquire(true);
+        let palette = ColorPalette::default();
+        let result = palette.success_text("transaction confirmed");
+        assert!(has_ansi(&result), "expected ANSI codes, got: {:?}", result);
+    }
+
+    #[test]
+    fn metadata_text_contains_ansi_when_colors_enabled() {
+        let _g = ColorGuard::acquire(true);
+        let palette = ColorPalette::default();
+        let result = palette.metadata_text("ledger: 12345");
+        assert!(has_ansi(&result), "expected ANSI codes, got: {:?}", result);
+    }
+
+    #[test]
+    fn muted_text_contains_ansi_when_colors_enabled() {
+        let _g = ColorGuard::acquire(true);
+        let palette = ColorPalette::default();
+        let result = palette.muted_text("optional detail");
+        assert!(has_ansi(&result), "expected ANSI codes, got: {:?}", result);
+    }
+
+    #[test]
+    fn accent_text_contains_ansi_when_colors_enabled() {
+        let _g = ColorGuard::acquire(true);
+        let palette = ColorPalette::default();
+        let result = palette.accent_text("highlighted");
+        assert!(has_ansi(&result), "expected ANSI codes, got: {:?}", result);
+    }
+
+    // ------------------------------------------------------------------ //
+    // Toggle / restore tests                                              //
+    // ------------------------------------------------------------------ //
+
+    #[test]
+    fn toggling_colors_off_then_on_restores_colored_output() {
+        let _g = ColorGuard::acquire(true);
+        let palette = ColorPalette::default();
+
+        // Sanity-check: colors are on.
+        let with_color = palette.error_text("err");
+        assert!(has_ansi(&with_color), "expected ANSI when enabled: {:?}", with_color);
+
+        // Disable colors.
+        set_color_enabled(false);
+        let without_color = palette.error_text("err");
+        assert_eq!(without_color, "err");
+        assert!(!has_ansi(&without_color), "expected no ANSI when disabled: {:?}", without_color);
+
+        // Re-enable colors — output should contain ANSI again.
+        set_color_enabled(true);
+        let restored = palette.error_text("err");
+        assert!(has_ansi(&restored), "expected ANSI restored: {:?}", restored);
+    }
+
+    #[test]
+    fn set_color_enabled_false_reflects_in_colors_enabled() {
+        let _g = ColorGuard::acquire(false);
+        assert!(!colors_enabled(), "colors_enabled() should return false after set_color_enabled(false)");
+    }
+
+    #[test]
+    fn set_color_enabled_true_reflects_in_colors_enabled() {
+        let _g = ColorGuard::acquire(true);
+        assert!(colors_enabled(), "colors_enabled() should return true after set_color_enabled(true)");
+    }
+}


### PR DESCRIPTION
## Summary

Adds comprehensive unit tests to `crates/cli/src/output/theme.rs` verifying that `ColorPalette` correctly suppresses ANSI escape codes in non-TTY environments (pipeline logs, file redirects, etc.).

Closes #423

## Changes

- Added a `#[cfg(test)]` module in `crates/cli/src/output/theme.rs` with **16 unit tests** across three groups:

### Non-TTY (colors disabled)
Verifies that `set_color_enabled(false)` causes all styling helpers to return raw, unformatted strings with zero `\x1b` (ANSI escape) characters:
- `error_text_no_ansi_when_colors_disabled`
- `warning_text_no_ansi_when_colors_disabled`
- `success_text_no_ansi_when_colors_disabled`
- `metadata_text_no_ansi_when_colors_disabled`
- `muted_text_no_ansi_when_colors_disabled`
- `accent_text_no_ansi_when_colors_disabled`
- `all_methods_return_raw_string_when_colors_disabled`

### TTY (colors enabled)
Verifies that `set_color_enabled(true)` causes all styling helpers to emit ANSI codes:
- `error_text_contains_ansi_when_colors_enabled`
- `warning_text_contains_ansi_when_colors_enabled`
- `success_text_contains_ansi_when_colors_enabled`
- `metadata_text_contains_ansi_when_colors_enabled`
- `muted_text_contains_ansi_when_colors_enabled`
- `accent_text_contains_ansi_when_colors_enabled`

### Toggle / restore
Verifies correct behavior when toggling the flag at runtime:
- `toggling_colors_off_then_on_restores_colored_output`
- `set_color_enabled_false_reflects_in_colors_enabled`
- `set_color_enabled_true_reflects_in_colors_enabled`

## Test infrastructure

A `ColorGuard` helper serializes all tests via a `Mutex` and automatically restores the original `COLOR_ENABLED` flag value after each test, preventing global-state interference between parallel test runners.

## Verification

```
cargo test -p grat output::theme

running 16 tests
test output::theme::tests::accent_text_contains_ansi_when_colors_enabled ... ok
test output::theme::tests::accent_text_no_ansi_when_colors_disabled ... ok
test output::theme::tests::all_methods_return_raw_string_when_colors_disabled ... ok
test output::theme::tests::error_text_contains_ansi_when_colors_enabled ... ok
test output::theme::tests::error_text_no_ansi_when_colors_disabled ... ok
test output::theme::tests::metadata_text_contains_ansi_when_colors_enabled ... ok
test output::theme::tests::metadata_text_no_ansi_when_colors_disabled ... ok
test output::theme::tests::muted_text_contains_ansi_when_colors_enabled ... ok
test output::theme::tests::muted_text_no_ansi_when_colors_disabled ... ok
test output::theme::tests::set_color_enabled_false_reflects_in_colors_enabled ... ok
test output::theme::tests::set_color_enabled_true_reflects_in_colors_enabled ... ok
test output::theme::tests::success_text_contains_ansi_when_colors_enabled ... ok
test output::theme::tests::success_text_no_ansi_when_colors_disabled ... ok
test output::theme::tests::toggling_colors_off_then_on_restores_colored_output ... ok
test output::theme::tests::warning_text_contains_ansi_when_colors_enabled ... ok
test output::theme::tests::warning_text_no_ansi_when_colors_disabled ... ok

test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 56 filtered out; finished in 0.00s
```

## Files changed

- `crates/cli/src/output/theme.rs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for themed text styling with colors enabled and disabled.
  * Verified color settings can be toggled and accurately reported.
  * Ensured color state is safely restored during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->